### PR TITLE
Refining emission

### DIFF
--- a/macro_data/data_wrapper.py
+++ b/macro_data/data_wrapper.py
@@ -22,6 +22,7 @@ from macro_data.readers import (
     compile_industry_data,
 )
 from macro_data.readers.exogenous_data import ExogenousCountryData
+from macro_data.readers.io_tables.icio_reader import ICIOReader
 
 
 @dataclass
@@ -263,6 +264,13 @@ class DataWrapper:
 
         emission_factors = readers.emissions.get_emissions_factors(year)
 
+        if all([emitting_ind in industries for emitting_ind in ["B05a", "B05b", "B05c"]]):
+            emission_factors["coke_refining"] = get_coke_refining_emissions(
+                readers.icio[year], emission_factors, country_names + ["ROW"], year
+            )
+        else:
+            emission_factors["coke_refining"] = np.mean(list(emission_factors.values()))
+
         return cls(
             synthetic_countries=synthetic_countries,
             synthetic_rest_of_the_world=synthetic_row,
@@ -440,3 +448,26 @@ def country_scaled_imports(
     imports = industry_data[country]["industry_vectors"]["Imports in USD"]
     scaled = scaled_imports[country]
     return pd.DataFrame(imports.values * scaled.values[:, np.newaxis], index=scaled.index).fillna(0)
+
+
+def get_country_coke_refining_emissions(
+    icio_reader: ICIOReader, emission_factors_array: np.ndarray, country: str | Country, year: int
+):
+    coefficients = (1 / icio_reader.get_intermediate_inputs_matrix(country)).loc["C19", ["B05a", "B05b", "B05c"]]
+    return coefficients @ emission_factors_array
+
+
+def get_coke_refining_emissions(
+    icio_reader: ICIOReader, emission_factors: dict[str, float], countries: list[str | Country], year: int
+):
+    factors_array = np.array(
+        [
+            emission_factors["coal"],
+            emission_factors["gas"],
+            emission_factors["oil"],
+        ]
+    )
+
+    return np.mean(
+        [get_country_coke_refining_emissions(icio_reader, factors_array, country, year) for country in countries]
+    )

--- a/macromodel/agents/firms/firms.py
+++ b/macromodel/agents/firms/firms.py
@@ -99,9 +99,12 @@ class Firms(Agent):
             coal_index = np.flatnonzero(synthetic_firms.industries == "B05a")
             gas_index = np.flatnonzero(synthetic_firms.industries == "B05b")
             oil_index = np.flatnonzero(synthetic_firms.industries == "B05c")
-            emitting_indices = np.concatenate([coal_index, gas_index, oil_index])
+            refining_index = np.flatnonzero(synthetic_firms.industries == "C19")
+            emitting_indices = np.concatenate([coal_index, gas_index, oil_index, refining_index])
             inputs_emissions = synthetic_firms.used_intermediate_inputs[:, emitting_indices] @ emission_factors_lcu
+            inputs_emissions[refining_index] = 0
             capital_emissions = synthetic_firms.used_capital_inputs[:, emitting_indices] @ emission_factors_lcu
+            capital_emissions[refining_index] = 0
         else:
             inputs_emissions = None
             capital_emissions = None

--- a/macromodel/agents/households/households.py
+++ b/macromodel/agents/households/households.py
@@ -163,9 +163,12 @@ class Households(Agent):
             coal_index = np.flatnonzero(industries == "B05a")
             gas_index = np.flatnonzero(industries == "B05b")
             oil_index = np.flatnonzero(industries == "B05c")
-            emitting_indices = np.concatenate([coal_index, gas_index, oil_index])
+            refining_index = np.flatnonzero(industries == "C19")
+            emitting_indices = np.concatenate([coal_index, gas_index, oil_index, refining_index])
             consumption_emissions = consumption_by_industry_hh[:, emitting_indices] @ emission_factors_lcu
-            investment_emissions = initial_investment.loc[:, ["B05a", "B05b", "B05c"]].values @ emission_factors_lcu
+            investment_emissions = (
+                initial_investment.loc[:, ["B05a", "B05b", "B05c", "C19"]].values @ emission_factors_lcu
+            )
         else:
             consumption_emissions = None
             investment_emissions = None

--- a/macromodel/country/country.py
+++ b/macromodel/country/country.py
@@ -129,7 +129,7 @@ class Country:
     ) -> "Country":
         scale = synthetic_country.scale
 
-        emission_industries = ["B05a", "B05b", "B05c"]
+        emission_industries = ["B05a", "B05b", "B05c", "C19"]
         add_emissions = all([industry in industries for industry in emission_industries])
 
         emission_factors_lcu = emission_factors_usd / exchange_rates.get_current_exchange_rates_from_usd_to_lcu(
@@ -197,9 +197,11 @@ class Country:
             coal_index = np.flatnonzero(industries == "B05a")
             oil_index = np.flatnonzero(industries == "B05b")
             gas_index = np.flatnonzero(industries == "B05c")
-            emitting_indices = np.concatenate([coal_index, oil_index, gas_index])
+            refining_index = np.flatnonzero(industries == "C19")
+            emitting_indices = np.concatenate([coal_index, oil_index, gas_index, refining_index])
         else:
             emitting_indices = None
+            refining_index = None
 
         government_entities = GovernmentEntities.from_pickled_agent(
             synthetic_government_entities=synthetic_country.government_entities,
@@ -852,6 +854,11 @@ class Country:
             used_capital_inputs = self.firms.compute_used_capital_inputs()
             inputs_emissions = used_intermediate_inputs[:, self.emitting_indices] @ readjusted_factors
             capital_emissions = used_capital_inputs[:, self.emitting_indices] @ readjusted_factors
+
+            refining_firms = self.firms.states["Industry"] == self.emitting_indices[-1]
+            inputs_emissions[refining_firms] = 0
+            capital_emissions[refining_firms] = 0
+
             self.firms.ts.inputs_emissions.append(inputs_emissions)
             self.firms.ts.capital_emissions.append(capital_emissions)
 

--- a/macromodel/simulation.py
+++ b/macromodel/simulation.py
@@ -66,6 +66,7 @@ class Simulation:
                 emission_factors["coal"],  # B05a
                 emission_factors["gas"],  # B05b
                 emission_factors["oil"],  # B05c
+                emission_factors["coke_refining"],  # C19
             ]
         )
 


### PR DESCRIPTION
Same as the previous PR, but now the C19 sector (coke and oil refining) has no direct emissions, instead it bundles up emissions into a good (like gasoline) with its own emissions coefficient, calculated taking the tCO2/USD from coal/oil/gas and weighing them with the technical coefficients to the C19 industry.