### PR TITLE
Bug fix for reproducibility

### DIFF
--- a/macromodel/simulation.py
+++ b/macromodel/simulation.py
@@ -99,8 +99,8 @@ class Simulation:
                     zero_initial_debt=False,
                     zero_initial_deposits=False,
                 )
-
-        countries_without_row = list(set(datawrapper.all_country_names) - {"ROW"})
+        
+        countries_without_row = [c for c in datawrapper.all_country_names if c != 'ROW']
         countries_with_row = datawrapper.all_country_names
 
         running_multi_country = len(countries_without_row) > 1


### PR DESCRIPTION
2 runs of simulation with same seed now produce same results.
Updates simulation.py L103 
Use of sets caused different ordering of countries_without_row on multi-country runs. 
Replaced with List comprehension to preserve ordering.
