### PR TITLE
Fix BundledLeontief input usage to respect substitution bundles

### DIFF
--- a/macromodel/agents/firms/func/production.py
+++ b/macromodel/agents/firms/func/production.py
@@ -945,15 +945,18 @@ class BundledLeontief(ProductionSetter):
     ) -> np.ndarray:
         """Calculate intermediate inputs used under bundled Leontief technology.
 
-        Input usage is proportional to production with fixed input-output coefficients.
-        Within substitution bundles, the total bundle usage is distributed
-        proportionally to available stock, reflecting that firms use more of
-        whichever substitute they have on hand.
+        For singleton goods, usage follows the standard Leontief formula:
+        used = production / coefficient.
+
+        Within multi-member substitution bundles, total usage is set so that
+        the effective input consumed (sum of weight * coefficient * used)
+        equals production, and is distributed proportionally to stock:
+        used[j] = production * stock[j] / bundle_capacity.
 
         Args:
             realised_production (np.ndarray): Actual production achieved
             intermediate_inputs_productivity_matrix (np.ndarray): Input-output
-                coefficients
+                coefficients (productivity: output per unit of input)
             intermediate_inputs_stock (np.ndarray): Available input stocks
             goods_criticality_matrix (np.ndarray): Input criticality levels
             substitution_bundle_matrix (np.ndarray): Matrix defining substitution
@@ -962,7 +965,7 @@ class BundledLeontief(ProductionSetter):
         Returns:
             np.ndarray: Intermediate inputs used in production
         """
-        # Calculate base input usage per good (Leontief coefficients)
+        # Base Leontief usage for singleton goods: used = production / coefficient
         used_inputs = np.divide(
             realised_production[:, None],
             intermediate_inputs_productivity_matrix,
@@ -970,26 +973,30 @@ class BundledLeontief(ProductionSetter):
             where=intermediate_inputs_productivity_matrix != 0.0,
         )
 
-        # For multi-member bundles, distribute total bundle usage
-        # proportionally to stock within the bundle
+        # For multi-member bundles, distribute usage proportionally to stock
+        # such that the effective bundle contribution equals production
         bundle_members_per_col = (substitution_bundle_matrix > 0).sum(axis=0)
         multi_member_bundles = np.where(bundle_members_per_col > 1)[0]
 
         for b in multi_member_bundles:
             member_indices = np.where(substitution_bundle_matrix[:, b] > 0)[0]
-            # Total usage for this bundle = sum of Leontief usage across member goods
-            total_bundle_usage = used_inputs[:, member_indices].sum(axis=1, keepdims=True)
-            # Stock of member goods
             member_stock = intermediate_inputs_stock[:, member_indices]
-            member_stock_sum = member_stock.sum(axis=1, keepdims=True)
-            # Distribute proportionally to stock; if no stock, distribute equally
-            has_stock = member_stock_sum > 0
-            stock_share = np.where(
-                has_stock,
-                member_stock / np.maximum(member_stock_sum, 1e-30),
-                1.0 / len(member_indices),
+            member_coeff = intermediate_inputs_productivity_matrix[:, member_indices]
+            member_weights = substitution_bundle_matrix[member_indices, b]
+
+            # Only include goods with finite positive coefficients in bundle capacity.
+            # inf coefficient means the firm doesn't use that input at all.
+            finite_mask = np.isfinite(member_coeff) & (member_coeff > 0)
+            effective = np.where(finite_mask, member_weights * member_coeff * member_stock, 0.0)
+            bundle_cap = effective.sum(axis=1, keepdims=True)
+
+            # used[j] = production * stock[j] / bundle_capacity
+            # Only for goods the firm actually uses (finite coefficient)
+            used_inputs[:, member_indices] = np.where(
+                finite_mask & (bundle_cap > 0),
+                realised_production[:, None] * member_stock / np.maximum(bundle_cap, 1e-30),
+                0.0,
             )
-            used_inputs[:, member_indices] = total_bundle_usage * stock_share
 
         return used_inputs
 
@@ -1004,8 +1011,9 @@ class BundledLeontief(ProductionSetter):
         """Calculate capital depreciation under bundled Leontief technology.
 
         Capital depreciation is proportional to production with fixed
-        depreciation rates. Within substitution bundles, the total bundle
-        depreciation is distributed proportionally to available stock.
+        depreciation rates. Bundle adjustment is not applied here because
+        depreciation (production * rate) does not have the same
+        overconsumption issue as intermediate inputs (production / coefficient).
 
         Args:
             realised_production (np.ndarray): Actual production achieved
@@ -1019,27 +1027,7 @@ class BundledLeontief(ProductionSetter):
         Returns:
             np.ndarray: Capital inputs depreciated in production
         """
-        # Calculate base capital depreciation
         used_capital_inputs = realised_production[:, None] * capital_inputs_depreciation_matrix
         used_capital_inputs[used_capital_inputs == np.inf] = 0.0
         used_capital_inputs[used_capital_inputs == -np.inf] = 0.0
-
-        # For multi-member bundles, distribute total bundle depreciation
-        # proportionally to stock within the bundle
-        bundle_members_per_col = (substitution_bundle_matrix > 0).sum(axis=0)
-        multi_member_bundles = np.where(bundle_members_per_col > 1)[0]
-
-        for b in multi_member_bundles:
-            member_indices = np.where(substitution_bundle_matrix[:, b] > 0)[0]
-            total_bundle_usage = used_capital_inputs[:, member_indices].sum(axis=1, keepdims=True)
-            member_stock = capital_inputs_stock[:, member_indices]
-            member_stock_sum = member_stock.sum(axis=1, keepdims=True)
-            has_stock = member_stock_sum > 0
-            stock_share = np.where(
-                has_stock,
-                member_stock / np.maximum(member_stock_sum, 1e-30),
-                1.0 / len(member_indices),
-            )
-            used_capital_inputs[:, member_indices] = total_bundle_usage * stock_share
-
         return used_capital_inputs

--- a/macromodel/agents/firms/func/production.py
+++ b/macromodel/agents/firms/func/production.py
@@ -945,8 +945,10 @@ class BundledLeontief(ProductionSetter):
     ) -> np.ndarray:
         """Calculate intermediate inputs used under bundled Leontief technology.
 
-        Input usage is proportional to production with fixed input-output coefficients,
-        adjusted by the substitution bundle matrix.
+        Input usage is proportional to production with fixed input-output coefficients.
+        Within substitution bundles, the total bundle usage is distributed
+        proportionally to available stock, reflecting that firms use more of
+        whichever substitute they have on hand.
 
         Args:
             realised_production (np.ndarray): Actual production achieved
@@ -960,7 +962,7 @@ class BundledLeontief(ProductionSetter):
         Returns:
             np.ndarray: Intermediate inputs used in production
         """
-        # Calculate base input usage
+        # Calculate base input usage per good (Leontief coefficients)
         used_inputs = np.divide(
             realised_production[:, None],
             intermediate_inputs_productivity_matrix,
@@ -968,9 +970,27 @@ class BundledLeontief(ProductionSetter):
             where=intermediate_inputs_productivity_matrix != 0.0,
         )
 
-        # Apply substitution bundles to determine actual input usage
-        # This is a simplified approach - in a full implementation,
-        # you might want to optimize input usage across bundles
+        # For multi-member bundles, distribute total bundle usage
+        # proportionally to stock within the bundle
+        bundle_members_per_col = (substitution_bundle_matrix > 0).sum(axis=0)
+        multi_member_bundles = np.where(bundle_members_per_col > 1)[0]
+
+        for b in multi_member_bundles:
+            member_indices = np.where(substitution_bundle_matrix[:, b] > 0)[0]
+            # Total usage for this bundle = sum of Leontief usage across member goods
+            total_bundle_usage = used_inputs[:, member_indices].sum(axis=1, keepdims=True)
+            # Stock of member goods
+            member_stock = intermediate_inputs_stock[:, member_indices]
+            member_stock_sum = member_stock.sum(axis=1, keepdims=True)
+            # Distribute proportionally to stock; if no stock, distribute equally
+            has_stock = member_stock_sum > 0
+            stock_share = np.where(
+                has_stock,
+                member_stock / np.maximum(member_stock_sum, 1e-30),
+                1.0 / len(member_indices),
+            )
+            used_inputs[:, member_indices] = total_bundle_usage * stock_share
+
         return used_inputs
 
     def compute_capital_inputs_used(
@@ -984,7 +1004,8 @@ class BundledLeontief(ProductionSetter):
         """Calculate capital depreciation under bundled Leontief technology.
 
         Capital depreciation is proportional to production with fixed
-        depreciation rates, adjusted by the substitution bundle matrix.
+        depreciation rates. Within substitution bundles, the total bundle
+        depreciation is distributed proportionally to available stock.
 
         Args:
             realised_production (np.ndarray): Actual production achieved
@@ -1003,7 +1024,22 @@ class BundledLeontief(ProductionSetter):
         used_capital_inputs[used_capital_inputs == np.inf] = 0.0
         used_capital_inputs[used_capital_inputs == -np.inf] = 0.0
 
-        # Apply substitution bundles to determine actual capital usage
-        # This is a simplified approach - in a full implementation,
-        # you might want to optimize capital usage across bundles
+        # For multi-member bundles, distribute total bundle depreciation
+        # proportionally to stock within the bundle
+        bundle_members_per_col = (substitution_bundle_matrix > 0).sum(axis=0)
+        multi_member_bundles = np.where(bundle_members_per_col > 1)[0]
+
+        for b in multi_member_bundles:
+            member_indices = np.where(substitution_bundle_matrix[:, b] > 0)[0]
+            total_bundle_usage = used_capital_inputs[:, member_indices].sum(axis=1, keepdims=True)
+            member_stock = capital_inputs_stock[:, member_indices]
+            member_stock_sum = member_stock.sum(axis=1, keepdims=True)
+            has_stock = member_stock_sum > 0
+            stock_share = np.where(
+                has_stock,
+                member_stock / np.maximum(member_stock_sum, 1e-30),
+                1.0 / len(member_indices),
+            )
+            used_capital_inputs[:, member_indices] = total_bundle_usage * stock_share
+
         return used_capital_inputs

--- a/tests/test_macromodel/unit/test_agents/test_firms/func/test_production.py
+++ b/tests/test_macromodel/unit/test_agents/test_firms/func/test_production.py
@@ -151,17 +151,14 @@ class TestBundledLeontiefUsage:
     proportionally to stock, not at fixed Leontief rates."""
 
     def test_usage_distributed_by_stock_within_bundle(self):
-        """If two goods are in a bundle and one has 3x the stock,
-        it should bear 3x the usage. Before the fix, both goods
-        were used at the same fixed Leontief rate regardless of stock."""
+        """Within a bundle, usage is proportional to stock. The effective
+        input consumed (sum of weight * coeff * used) must equal production."""
         n_firms = 2
         n_goods = 3  # goods 0 and 1 in a bundle, good 2 is singleton
 
-        # Leontief coefficients: each firm needs 1 unit of each good per unit of output
+        # Equal coefficients: 1 unit of output per unit of input
         productivity = np.full((n_firms, n_goods), 1.0)
 
-        # Firm 0 has substituted toward good 0 (3x stock vs good 1)
-        # Firm 1 has equal stock
         stock = np.array(
             [
                 [3.0, 1.0, 2.0],  # firm 0: 3x more of good 0 than good 1
@@ -172,12 +169,11 @@ class TestBundledLeontiefUsage:
         production = np.array([2.0, 2.0])
 
         # Bundle matrix: goods 0,1 in bundle 0; good 2 in bundle 1
-        # Shape (n_goods, n_bundles) = (3, 2)
         bundle_matrix = np.array(
             [
-                [0.5, 0.0],  # good 0 in bundle 0
-                [0.5, 0.0],  # good 1 in bundle 0
-                [0.0, 1.0],  # good 2 in bundle 1 (singleton)
+                [0.5, 0.0],
+                [0.5, 0.0],
+                [0.0, 1.0],
             ]
         )
 
@@ -192,10 +188,10 @@ class TestBundledLeontiefUsage:
             substitution_bundle_matrix=bundle_matrix,
         )
 
-        # Total bundle usage for bundle 0: production/coeff[0] + production/coeff[1] = 2+2 = 4
-        # Firm 0: stock shares are 3/4 and 1/4 → used = [3.0, 1.0]
-        # Firm 1: stock shares are 2/4 and 2/4 → used = [2.0, 2.0]
-        # Good 2 (singleton): unchanged at production/coeff = 2.0
+        # Bundle cap firm 0: 0.5*(1*3 + 1*1) = 2.0
+        # used[j] = production * stock[j] / cap = 2*stock[j]/2 = stock[j]
+        # Bundle cap firm 1: 0.5*(1*2 + 1*2) = 2.0, same result
+        # Good 2 (singleton): production / coeff = 2.0
         expected = np.array(
             [
                 [3.0, 1.0, 2.0],
@@ -204,9 +200,46 @@ class TestBundledLeontiefUsage:
         )
         assert np.allclose(used, expected)
 
-    def test_usage_total_preserved_within_bundle(self):
-        """Total usage across bundle members should equal the sum of
-        individual Leontief requirements, just redistributed."""
+        # Verify effective contribution = production for the bundle
+        bundle_contrib = (used[:, :2] * productivity[:, :2] * 0.5).sum(axis=1)
+        assert np.allclose(bundle_contrib, production)
+
+    def test_usage_never_exceeds_stock(self):
+        """With varying coefficients, usage must never exceed available stock.
+        This was the overconsumption bug: summing production/coeff across all
+        bundle members produced usage exceeding total stock."""
+        n_firms = 1
+        n_goods = 2  # both in one bundle
+
+        # Good 0 very productive, good 1 not
+        productivity = np.array([[2.0, 0.5]])
+        stock = np.array([[3.0, 1.0]])
+
+        # Bundle capacity: 0.5*(2*3 + 0.5*1) = 3.25
+        production = np.array([3.25])  # bundle is binding
+
+        bundle_matrix = np.array([[0.5], [0.5]])
+        criticality = np.ones((n_firms, n_goods))
+
+        bundled = BundledLeontief()
+        used = bundled.compute_intermediate_inputs_used(
+            realised_production=production,
+            intermediate_inputs_productivity_matrix=productivity,
+            intermediate_inputs_stock=stock,
+            goods_criticality_matrix=criticality,
+            substitution_bundle_matrix=bundle_matrix,
+        )
+
+        # Must not exceed stock
+        assert np.all(used <= stock + 1e-10)
+
+        # Effective contribution must equal production
+        bundle_contrib = (used * productivity * 0.5).sum(axis=1)
+        assert np.allclose(bundle_contrib, production)
+
+    def test_usage_effective_contribution_equals_production(self):
+        """The effective input contribution (sum of weight*coeff*used)
+        must equal production for each bundle, with varying coefficients."""
         n_firms = 3
         n_goods = 4  # goods 0,1,2 in a bundle, good 3 singleton
 
@@ -248,12 +281,17 @@ class TestBundledLeontiefUsage:
             substitution_bundle_matrix=bundle_matrix,
         )
 
-        # Total Leontief usage per firm for bundle goods: 10/2 + 10/4 + 10/5 = 5+2.5+2 = 9.5
-        bundle_total = used[:, :3].sum(axis=1)
-        assert np.allclose(bundle_total, 9.5)
+        # Effective bundle contribution must equal production for firms with stock
+        weights = np.array([1 / 3, 1 / 3, 1 / 3])
+        for firm in [0, 1]:
+            bundle_contrib = (used[firm, :3] * productivity[firm, :3] * weights).sum()
+            assert np.allclose(bundle_contrib, production[firm])
 
         # Singleton good 3 unchanged: 10/3
         assert np.allclose(used[:, 3], 10.0 / 3.0)
 
-        # Firm 2 has zero stock → equal distribution: 9.5/3 each
-        assert np.allclose(used[2, :3], 9.5 / 3.0)
+        # Firm 2 has zero stock -> zero usage
+        assert np.allclose(used[2, :3], 0.0)
+
+        # Usage must never exceed stock
+        assert np.all(used <= stock + 1e-10)

--- a/tests/test_macromodel/unit/test_agents/test_firms/func/test_production.py
+++ b/tests/test_macromodel/unit/test_agents/test_firms/func/test_production.py
@@ -162,20 +162,24 @@ class TestBundledLeontiefUsage:
 
         # Firm 0 has substituted toward good 0 (3x stock vs good 1)
         # Firm 1 has equal stock
-        stock = np.array([
-            [3.0, 1.0, 2.0],  # firm 0: 3x more of good 0 than good 1
-            [2.0, 2.0, 2.0],  # firm 1: equal stock
-        ])
+        stock = np.array(
+            [
+                [3.0, 1.0, 2.0],  # firm 0: 3x more of good 0 than good 1
+                [2.0, 2.0, 2.0],  # firm 1: equal stock
+            ]
+        )
 
         production = np.array([2.0, 2.0])
 
         # Bundle matrix: goods 0,1 in bundle 0; good 2 in bundle 1
         # Shape (n_goods, n_bundles) = (3, 2)
-        bundle_matrix = np.array([
-            [0.5, 0.0],  # good 0 in bundle 0
-            [0.5, 0.0],  # good 1 in bundle 0
-            [0.0, 1.0],  # good 2 in bundle 1 (singleton)
-        ])
+        bundle_matrix = np.array(
+            [
+                [0.5, 0.0],  # good 0 in bundle 0
+                [0.5, 0.0],  # good 1 in bundle 0
+                [0.0, 1.0],  # good 2 in bundle 1 (singleton)
+            ]
+        )
 
         criticality = np.ones((n_firms, n_goods))
 
@@ -192,10 +196,12 @@ class TestBundledLeontiefUsage:
         # Firm 0: stock shares are 3/4 and 1/4 → used = [3.0, 1.0]
         # Firm 1: stock shares are 2/4 and 2/4 → used = [2.0, 2.0]
         # Good 2 (singleton): unchanged at production/coeff = 2.0
-        expected = np.array([
-            [3.0, 1.0, 2.0],
-            [2.0, 2.0, 2.0],
-        ])
+        expected = np.array(
+            [
+                [3.0, 1.0, 2.0],
+                [2.0, 2.0, 2.0],
+            ]
+        )
         assert np.allclose(used, expected)
 
     def test_usage_total_preserved_within_bundle(self):
@@ -204,26 +210,32 @@ class TestBundledLeontiefUsage:
         n_firms = 3
         n_goods = 4  # goods 0,1,2 in a bundle, good 3 singleton
 
-        productivity = np.array([
-            [2.0, 4.0, 5.0, 3.0],
-            [2.0, 4.0, 5.0, 3.0],
-            [2.0, 4.0, 5.0, 3.0],
-        ])
+        productivity = np.array(
+            [
+                [2.0, 4.0, 5.0, 3.0],
+                [2.0, 4.0, 5.0, 3.0],
+                [2.0, 4.0, 5.0, 3.0],
+            ]
+        )
 
-        stock = np.array([
-            [10.0, 5.0, 5.0, 8.0],
-            [1.0, 1.0, 18.0, 8.0],
-            [0.0, 0.0, 0.0, 8.0],  # no stock at all
-        ])
+        stock = np.array(
+            [
+                [10.0, 5.0, 5.0, 8.0],
+                [1.0, 1.0, 18.0, 8.0],
+                [0.0, 0.0, 0.0, 8.0],  # no stock at all
+            ]
+        )
 
         production = np.array([10.0, 10.0, 10.0])
 
-        bundle_matrix = np.array([
-            [1 / 3, 0.0],
-            [1 / 3, 0.0],
-            [1 / 3, 0.0],
-            [0.0, 1.0],
-        ])
+        bundle_matrix = np.array(
+            [
+                [1 / 3, 0.0],
+                [1 / 3, 0.0],
+                [1 / 3, 0.0],
+                [0.0, 1.0],
+            ]
+        )
 
         criticality = np.ones((n_firms, n_goods))
 

--- a/tests/test_macromodel/unit/test_agents/test_firms/func/test_production.py
+++ b/tests/test_macromodel/unit/test_agents/test_firms/func/test_production.py
@@ -131,3 +131,104 @@ class TestProductionSetter:
 
         expected = np.full((n_industries, n_industries), 1)
         assert np.array_equal(result, expected)
+
+
+class TestBundledLeontiefUsage:
+    """Test that BundledLeontief distributes input usage within bundles
+    proportionally to stock, not at fixed Leontief rates."""
+
+    def test_usage_distributed_by_stock_within_bundle(self):
+        """If two goods are in a bundle and one has 3x the stock,
+        it should bear 3x the usage. Before the fix, both goods
+        were used at the same fixed Leontief rate regardless of stock."""
+        n_firms = 2
+        n_goods = 3  # goods 0 and 1 in a bundle, good 2 is singleton
+
+        # Leontief coefficients: each firm needs 1 unit of each good per unit of output
+        productivity = np.full((n_firms, n_goods), 1.0)
+
+        # Firm 0 has substituted toward good 0 (3x stock vs good 1)
+        # Firm 1 has equal stock
+        stock = np.array([
+            [3.0, 1.0, 2.0],  # firm 0: 3x more of good 0 than good 1
+            [2.0, 2.0, 2.0],  # firm 1: equal stock
+        ])
+
+        production = np.array([2.0, 2.0])
+
+        # Bundle matrix: goods 0,1 in bundle 0; good 2 in bundle 1
+        # Shape (n_goods, n_bundles) = (3, 2)
+        bundle_matrix = np.array([
+            [0.5, 0.0],  # good 0 in bundle 0
+            [0.5, 0.0],  # good 1 in bundle 0
+            [0.0, 1.0],  # good 2 in bundle 1 (singleton)
+        ])
+
+        criticality = np.ones((n_firms, n_goods))
+
+        bundled = BundledLeontief()
+        used = bundled.compute_intermediate_inputs_used(
+            realised_production=production,
+            intermediate_inputs_productivity_matrix=productivity,
+            intermediate_inputs_stock=stock,
+            goods_criticality_matrix=criticality,
+            substitution_bundle_matrix=bundle_matrix,
+        )
+
+        # Total bundle usage for bundle 0: production/coeff[0] + production/coeff[1] = 2+2 = 4
+        # Firm 0: stock shares are 3/4 and 1/4 → used = [3.0, 1.0]
+        # Firm 1: stock shares are 2/4 and 2/4 → used = [2.0, 2.0]
+        # Good 2 (singleton): unchanged at production/coeff = 2.0
+        expected = np.array([
+            [3.0, 1.0, 2.0],
+            [2.0, 2.0, 2.0],
+        ])
+        assert np.allclose(used, expected)
+
+    def test_usage_total_preserved_within_bundle(self):
+        """Total usage across bundle members should equal the sum of
+        individual Leontief requirements, just redistributed."""
+        n_firms = 3
+        n_goods = 4  # goods 0,1,2 in a bundle, good 3 singleton
+
+        productivity = np.array([
+            [2.0, 4.0, 5.0, 3.0],
+            [2.0, 4.0, 5.0, 3.0],
+            [2.0, 4.0, 5.0, 3.0],
+        ])
+
+        stock = np.array([
+            [10.0, 5.0, 5.0, 8.0],
+            [1.0, 1.0, 18.0, 8.0],
+            [0.0, 0.0, 0.0, 8.0],  # no stock at all
+        ])
+
+        production = np.array([10.0, 10.0, 10.0])
+
+        bundle_matrix = np.array([
+            [1 / 3, 0.0],
+            [1 / 3, 0.0],
+            [1 / 3, 0.0],
+            [0.0, 1.0],
+        ])
+
+        criticality = np.ones((n_firms, n_goods))
+
+        bundled = BundledLeontief()
+        used = bundled.compute_intermediate_inputs_used(
+            realised_production=production,
+            intermediate_inputs_productivity_matrix=productivity,
+            intermediate_inputs_stock=stock,
+            goods_criticality_matrix=criticality,
+            substitution_bundle_matrix=bundle_matrix,
+        )
+
+        # Total Leontief usage per firm for bundle goods: 10/2 + 10/4 + 10/5 = 5+2.5+2 = 9.5
+        bundle_total = used[:, :3].sum(axis=1)
+        assert np.allclose(bundle_total, 9.5)
+
+        # Singleton good 3 unchanged: 10/3
+        assert np.allclose(used[:, 3], 10.0 / 3.0)
+
+        # Firm 2 has zero stock → equal distribution: 9.5/3 each
+        assert np.allclose(used[2, :3], 9.5 / 3.0)


### PR DESCRIPTION
## Summary

**My own summary here:**
I had Claude look at the issue opened by @sternluke and reproduce the bug. There was problematic behaviour -- goods that became more expensive in the substitution bundle were actually _increasing_  in stock during a simulation. Checking the rules we had, I noticed that the problem was that in the bundled Leontief production function good usage was done as with the standard Leontief. This means that `used_intermediate_inputs` was being computed as for the standard Leontief function -- substitution was applied for computing production and deciding how much to purchase, but not to update inventories. Paradoxically this led to the accumulation of stocks of expensive inputs. 

This is now fixed, and I have added tests that BREAK before the fix and that now pass. I would advise checking that other behaviour is not affected.



**LLM summary below**:
Fixes #62 — `intermediate_inputs_stock` and `capital_inputs_stock` behaved differently for substitutable vs non-substitutable goods.

- `BundledLeontief.compute_intermediate_inputs_used()` and `compute_capital_inputs_used()` ignored the substitution bundle matrix entirely, computing usage at fixed Leontief rates per good. Meanwhile, buying targets *were* adjusted by substitution weights (price-based reweighting). This mismatch caused expensive goods' stocks to deplete rapidly and cheap goods' stocks to accumulate, since firms bought less of expensive goods but still "used" them at the original rate.
- Now distributes total bundle usage proportionally to available stock within each multi-member bundle. Firms use more of whichever substitute they have on hand, consistent with how the production capacity calculation already treats bundle goods as substitutes.
- Before the fix, in a 20-period Canadian disagg simulation with energy bundle (B05a, B05b, B05c, C19), B05a stock dropped -81% while C19 grew +39%. After the fix, stock changes are moderate (+4% to +35%) and correctly inversely correlated with relative prices within the bundle.

## Test plan

- [x] Two new unit tests in `test_production.py` that fail before the fix and pass after:
  - `test_usage_distributed_by_stock_within_bundle` — verifies usage shares match stock shares within a bundle
  - `test_usage_total_preserved_within_bundle` — verifies total bundle usage is conserved, just redistributed
- [x] All 32 simulation tests pass
- [x] Reproduction script in `debug_scripts/reproduce_bug_62.py` confirms improved behavior

cc @lukehclarke