### PR TITLE
Fix Conda env for osx-arm64

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,10 +6,10 @@ channels:
 dependencies:
 - python=3.12
 - black=24.4.2
-- cvxpy=1.6.0
+- cvxpy=1.7.2
 - isort=5.13.2
 - jupyterlab=4.2.7
-- matplotlib=3.7.5
+- matplotlib=3.10.6
 - notebook=7.2.2
 - numba=0.59.1
 - pandas=2.2.2


### PR DESCRIPTION
Installing from conda using environment.yml fails because cvxpy and matplotlib stuggles on Apple Silicon osx-arm64.
Packages require new versions that can fit the requirements in Python 3.12.
"Conda could not find builds of matplotlib 3.7.5 and cvxpy 1.6.0 in your configured channels that satisfy osx-arm64 and the rest of this environment.” 

Suggested update
cvxpy=1.7.2
matplotlib=3.10.6
