### PR TITLE
growth handling in `ConstantGrowthGovernmentConsumptionSetter`.

### DIFF
--- a/macromodel/agents/government_entities/func/consumption.py
+++ b/macromodel/agents/government_entities/func/consumption.py
@@ -270,24 +270,31 @@ class ConstantGrowthGovernmentConsumptionSetter(GovernmentConsumptionSetter):
             np.ndarray: Target consumption by industry
         """
         if historic_total_consumption is None:
-            return np.maximum(
-                0.0,
-                (1 + expected_inflation) * (1 + self.default_growth) * previous_desired_government_consumption,
-            )
-        if self.default_growth is None:
-            self.default_growth = np.mean(
+            if self.default_growth is None:
+                raise ValueError(
+                    "ConstantGrowthGovernmentConsumptionSetter requires either "
+                    "historic_total_consumption or a configured default_growth."
+                )
+            growth_factor = 1 + self.default_growth
+        elif self.default_growth is None:
+            estimated_log_growth = np.mean(
                 np.log(
                     historic_total_consumption[1 : -current_time - 1]
                     / historic_total_consumption[0 : -current_time - 2]
                 )
             )
+            self.default_growth = np.exp(estimated_log_growth) - 1
+            growth_factor = 1 + self.default_growth
+        else:
+            growth_factor = 1 + self.default_growth
+
 
         return np.maximum(
             0.0,
             (1 + expected_inflation)
             * current_good_prices
             / initial_good_prices
-            * (1 + self.default_growth)
+            * growth_factor
             * previous_desired_government_consumption,
         )
 

--- a/macromodel/agents/government_entities/func/consumption.py
+++ b/macromodel/agents/government_entities/func/consumption.py
@@ -288,7 +288,6 @@ class ConstantGrowthGovernmentConsumptionSetter(GovernmentConsumptionSetter):
         else:
             growth_factor = 1 + self.default_growth
 
-
         return np.maximum(
             0.0,
             (1 + expected_inflation)

--- a/macromodel/agents/government_entities/func/consumption.py
+++ b/macromodel/agents/government_entities/func/consumption.py
@@ -25,6 +25,16 @@ from macromodel.forecaster.forecaster import (
 )
 
 
+def _normalise_government_consumption_weights(previous_desired_government_consumption: np.ndarray) -> np.ndarray:
+    """Return stable industry weights for government consumption targets."""
+    weights = np.asarray(previous_desired_government_consumption, dtype=float)
+    weights = np.where(np.isfinite(weights) & (weights > 0.0), weights, 0.0)
+    weights_sum = weights.sum()
+    if weights_sum <= 0.0:
+        return np.full(weights.shape, 1.0 / len(weights))
+    return weights / weights_sum
+
+
 class GovernmentConsumptionSetter(ABC):
     """Abstract base class for government consumption strategies.
 
@@ -200,14 +210,10 @@ class AutoregressiveGovernmentConsumptionSetter(GovernmentConsumptionSetter):
             )
 
         # Weighted by prices
+        consumption_weights = _normalise_government_consumption_weights(previous_desired_government_consumption)
         return np.maximum(
             0.0,
-            (1 + expected_inflation)
-            * current_good_prices
-            / initial_good_prices
-            * consumption
-            * previous_desired_government_consumption
-            / previous_desired_government_consumption.sum(),
+            (1 + expected_inflation) * current_good_prices / initial_good_prices * consumption * consumption_weights,
         )
 
 
@@ -396,14 +402,10 @@ class AutoregressiveGrowthGovernmentConsumptionSetter(GovernmentConsumptionSette
             )
 
         # Weighted by prices
+        consumption_weights = _normalise_government_consumption_weights(previous_desired_government_consumption)
         return np.maximum(
             0.0,
-            (1 + expected_inflation)
-            * current_good_prices
-            / initial_good_prices
-            * consumption
-            * previous_desired_government_consumption
-            / previous_desired_government_consumption.sum(),
+            (1 + expected_inflation) * current_good_prices / initial_good_prices * consumption * consumption_weights,
         )
 
 
@@ -479,11 +481,16 @@ class ExogenousGovernmentConsumptionSetter(GovernmentConsumptionSetter):
             )
         if current_time >= len(exogenous_total_consumption):
             raise ValueError("No exogenous data available beyond this point.")
+        if not np.isfinite(exogenous_total_consumption[current_time]):
+            raise ValueError(
+                "ExogenousGovernmentConsumptionSetter: non-finite exogenous government consumption with "
+                f"current_time={current_time}, value={exogenous_total_consumption[current_time]}"
+            )
+        consumption_weights = _normalise_government_consumption_weights(previous_desired_government_consumption)
         return (
             (1 + expected_inflation)
             * current_good_prices
             / initial_good_prices
             * exogenous_total_consumption[current_time]
-            * previous_desired_government_consumption
-            / previous_desired_government_consumption.sum()
+            * consumption_weights
         )


### PR DESCRIPTION
This PR fixes a bug in `ConstantGrowthGovernmentConsumptionSetter`.

If `default_growth` is not provided in config, the setter estimates growth from historical government consumption. The code was estimating growth in log terms, but then reusing it as if it were a standard percentage growth rate. That mixes two different definitions of growth and makes the update inconsistent.

This PR fixes that by converting the estimated log growth into a standard growth rate before storing and reusing it. It also adds a guard so the setter fails clearly if neither historical consumption data nor a configured `default_growth` is available.

EDIT
The PR also normalise government consumption weights when these are zero, nan, inf:
_normalise_government_consumption_weights converts positive finite sectoral government consumption values into shares summing to 1, falling back to uniform shares if no valid positive mass exists.

