### PR TITLE
SmoothTaylorRule + time-unit aware rate

### DIFF
--- a/macro_data/data_wrapper.py
+++ b/macro_data/data_wrapper.py
@@ -106,7 +106,7 @@ class DataWrapper:
     emission_factors: dict[str, float]
     emissions_energy_factors: Optional[EmissionsEnergyFactors] = None
     aggregation_structure: Optional[dict[Country, list[Country | Region]]] = None
-    time_unit: int = 4.0
+    time_unit: int = 3
 
     @property
     def all_country_names(self) -> list[str]:
@@ -291,6 +291,7 @@ class DataWrapper:
                 country=country,
                 year=year,
                 quarter=quarter,
+                time_unit=configuration.time_unit,
                 country_configuration=configuration.country_configs[country],
                 industries=industries,
                 readers=readers,
@@ -316,6 +317,7 @@ class DataWrapper:
                     country=country,
                     proxy_country=configuration.country_configs[country].eu_proxy_country,
                     year=year,
+                    time_unit=configuration.time_unit,
                     country_configuration=configuration.country_configs[country],
                     industries=industries,
                     readers=readers,

--- a/macro_data/processing/synthetic_banks/default_synthetic_banks.py
+++ b/macro_data/processing/synthetic_banks/default_synthetic_banks.py
@@ -386,7 +386,9 @@ class DefaultSyntheticBanks(SyntheticBanks):
         return annual_rate / cls._periods_per_year(time_unit)
 
     @classmethod
-    def _convert_annual_rate_series_to_period(cls, annual_rates: Optional[pd.Series], time_unit: int) -> Optional[pd.Series]:
+    def _convert_annual_rate_series_to_period(
+        cls, annual_rates: Optional[pd.Series], time_unit: int
+    ) -> Optional[pd.Series]:
         """Convert a quoted annual rate series to per-period units."""
         if annual_rates is None:
             return None
@@ -453,7 +455,9 @@ class DefaultSyntheticBanks(SyntheticBanks):
             if proxy_eu_country is None:
                 raise ValueError("Proxy EU country is required for non-EU countries.")
             data_country = proxy_eu_country
-        firm_rate = cls._convert_annual_rate_series_to_period(readers.ecb_reader.get_firm_rates(data_country), time_unit)
+        firm_rate = cls._convert_annual_rate_series_to_period(
+            readers.ecb_reader.get_firm_rates(data_country), time_unit
+        )
         household_consumption_rate = cls._convert_annual_rate_series_to_period(
             readers.ecb_reader.get_household_consumption_rates(data_country),
             time_unit,

--- a/macro_data/processing/synthetic_banks/default_synthetic_banks.py
+++ b/macro_data/processing/synthetic_banks/default_synthetic_banks.py
@@ -40,6 +40,7 @@ from macro_data.processing.synthetic_banks.rates_utils import (
 )
 from macro_data.processing.synthetic_banks.synthetic_banks import SyntheticBanks
 from macro_data.readers.default_readers import DataReaders
+from macro_data.util.frequency import annual_to_period
 
 
 class DefaultSyntheticBanks(SyntheticBanks):
@@ -226,7 +227,7 @@ class DefaultSyntheticBanks(SyntheticBanks):
             hh_mortgage_rate,
         ) = cls.initialise_rates(country_name, inflation_data, proxy_eu_country, quarter, readers, year, time_unit)
 
-        initial_policy_rates = cls._convert_annual_rate_frame_to_period(
+        initial_policy_rates = annual_to_period(
             readers.policy_rates.get_policy_rates(country_name),
             time_unit,
             "Policy Rate",
@@ -344,7 +345,7 @@ class DefaultSyntheticBanks(SyntheticBanks):
             hh_mortgage_rate,
         ) = cls.initialise_rates(country_name, inflation_data, proxy_eu_country, quarter, readers, year, time_unit)
 
-        initial_policy_rates = cls._convert_annual_rate_frame_to_period(
+        initial_policy_rates = annual_to_period(
             readers.policy_rates.get_policy_rates(country_name),
             time_unit,
             "Policy Rate",
@@ -371,40 +372,6 @@ class DefaultSyntheticBanks(SyntheticBanks):
             hh_mortgage_rate=hh_mortgage_rate,
             quarter=quarter,
         )
-
-    @classmethod
-    @staticmethod
-    def _periods_per_year(time_unit: int) -> int:
-        """Return the number of model periods in one calendar year."""
-        if time_unit <= 0 or 12 % time_unit != 0:
-            raise ValueError("Bank-rate preprocessing requires `time_unit` to be a positive divisor of 12.")
-        return 12 // time_unit
-
-    @classmethod
-    def _convert_annual_rate_to_period(cls, annual_rate: float, time_unit: int) -> float:
-        """Convert an annual quoted rate to the model's per-period convention."""
-        return annual_rate / cls._periods_per_year(time_unit)
-
-    @classmethod
-    def _convert_annual_rate_series_to_period(
-        cls, annual_rates: Optional[pd.Series], time_unit: int
-    ) -> Optional[pd.Series]:
-        """Convert a quoted annual rate series to per-period units."""
-        if annual_rates is None:
-            return None
-        return annual_rates.astype(float) / cls._periods_per_year(time_unit)
-
-    @classmethod
-    def _convert_annual_rate_frame_to_period(
-        cls,
-        annual_rates: pd.DataFrame,
-        time_unit: int,
-        column: str,
-    ) -> pd.DataFrame:
-        """Convert a quoted annual-rate column in a DataFrame to per-period units."""
-        period_rates = annual_rates.copy()
-        period_rates[column] = period_rates[column].astype(float) / cls._periods_per_year(time_unit)
-        return period_rates
 
     @staticmethod
     def _initial_policy_rate_quarter_key(year: int, quarter: int) -> str:
@@ -455,22 +422,13 @@ class DefaultSyntheticBanks(SyntheticBanks):
             if proxy_eu_country is None:
                 raise ValueError("Proxy EU country is required for non-EU countries.")
             data_country = proxy_eu_country
-        firm_rate = cls._convert_annual_rate_series_to_period(
-            readers.ecb_reader.get_firm_rates(data_country), time_unit
-        )
-        household_consumption_rate = cls._convert_annual_rate_series_to_period(
+        firm_rate = annual_to_period(readers.ecb_reader.get_firm_rates(data_country), time_unit)
+        household_consumption_rate = annual_to_period(
             readers.ecb_reader.get_household_consumption_rates(data_country),
             time_unit,
         )
-        household_mortgage_rates = cls._convert_annual_rate_series_to_period(
-            readers.ecb_reader.get_household_mortgage_rates(data_country),
-            time_unit,
-        )
-        policy_rates = cls._convert_annual_rate_frame_to_period(
-            readers.policy_rates.get_policy_rates(data_country),
-            time_unit,
-            "Policy Rate",
-        )
+        household_mortgage_rates = annual_to_period(readers.ecb_reader.get_household_mortgage_rates(data_country), time_unit)
+        policy_rates = annual_to_period(readers.policy_rates.get_policy_rates(data_country), time_unit, "Policy Rate")
         npl_rates = readers.world_bank.get_npl_ratios(data_country)
         if any(
             [

--- a/macro_data/processing/synthetic_banks/default_synthetic_banks.py
+++ b/macro_data/processing/synthetic_banks/default_synthetic_banks.py
@@ -147,6 +147,7 @@ class DefaultSyntheticBanks(SyntheticBanks):
         banks_data_configuration: BanksDataConfiguration,
         quarter: int,
         inflation_data: pd.DataFrame,
+        time_unit: int,
         exchange_rate_from_eur: float = 1.0,
         proxy_eu_country: Optional[Country] = None,
     ) -> "DefaultSyntheticBanks":
@@ -171,6 +172,8 @@ class DefaultSyntheticBanks(SyntheticBanks):
             banks_data_configuration (BanksDataConfiguration): Preprocessing configuration
             quarter (int): Reference quarter for preprocessing
             inflation_data (pd.DataFrame): Historical inflation data
+            time_unit (int): Simulation period length in months. Historical quoted
+                annual rates are converted to per-period units using this value.
             exchange_rate_from_eur (float, optional): Exchange rate for conversion. Defaults to 1.0.
             proxy_eu_country (Optional[Country], optional): EU country for proxy data. Defaults to None.
 
@@ -186,6 +189,7 @@ class DefaultSyntheticBanks(SyntheticBanks):
                 scale=scale,
                 quarter=quarter,
                 inflation_data=inflation_data,
+                time_unit=time_unit,
                 exchange_rate_from_eur=exchange_rate_from_eur,
                 proxy_eu_country=proxy_eu_country,
             )
@@ -220,11 +224,15 @@ class DefaultSyntheticBanks(SyntheticBanks):
             hh_mortgage_ect,
             hh_mortgage_passthrough,
             hh_mortgage_rate,
-        ) = cls.initialise_rates(country_name, inflation_data, proxy_eu_country, quarter, readers, year)
+        ) = cls.initialise_rates(country_name, inflation_data, proxy_eu_country, quarter, readers, year, time_unit)
 
-        initial_central_bank_policy_rate = (
-            readers.policy_rates.get_policy_rates(country_name).loc[f"{year}-Q{quarter}", "Policy Rate"].values[0]
+        initial_policy_rates = cls._convert_annual_rate_frame_to_period(
+            readers.policy_rates.get_policy_rates(country_name),
+            time_unit,
+            "Policy Rate",
         )
+        initial_quarter_key = cls._initial_policy_rate_quarter_key(year, quarter)
+        initial_central_bank_policy_rate = initial_policy_rates.loc[initial_quarter_key, "Policy Rate"].values[0]
 
         bank_data["Interest Rates on Firm Deposits"] = initial_central_bank_policy_rate
         bank_data["Interest Rates on Household Deposits"] = initial_central_bank_policy_rate
@@ -257,6 +265,7 @@ class DefaultSyntheticBanks(SyntheticBanks):
         scale: int,
         quarter: int,
         inflation_data: pd.DataFrame,
+        time_unit: int,
         exchange_rate_from_eur: float = 1.0,
         proxy_eu_country: Optional[Country] = None,
     ) -> "DefaultSyntheticBanks":
@@ -281,6 +290,8 @@ class DefaultSyntheticBanks(SyntheticBanks):
             scale (int): Scaling factor for bank numbers
             quarter (int): Reference quarter for preprocessing
             inflation_data (pd.DataFrame): Historical inflation data
+            time_unit (int): Simulation period length in months. Historical quoted
+                annual rates are converted to per-period units using this value.
             exchange_rate_from_eur (float, optional): Exchange rate for conversion. Defaults to 1.0.
             proxy_eu_country (Optional[Country], optional): EU country for proxy data. Defaults to None.
 
@@ -331,11 +342,15 @@ class DefaultSyntheticBanks(SyntheticBanks):
             hh_mortgage_ect,
             hh_mortgage_passthrough,
             hh_mortgage_rate,
-        ) = cls.initialise_rates(country_name, inflation_data, proxy_eu_country, quarter, readers, year)
+        ) = cls.initialise_rates(country_name, inflation_data, proxy_eu_country, quarter, readers, year, time_unit)
 
-        initial_central_bank_policy_rate = (
-            readers.policy_rates.get_policy_rates(country_name).loc[f"{year}-Q{quarter}", "Policy Rate"].values[0]
+        initial_policy_rates = cls._convert_annual_rate_frame_to_period(
+            readers.policy_rates.get_policy_rates(country_name),
+            time_unit,
+            "Policy Rate",
         )
+        initial_quarter_key = cls._initial_policy_rate_quarter_key(year, quarter)
+        initial_central_bank_policy_rate = initial_policy_rates.loc[initial_quarter_key, "Policy Rate"].values[0]
 
         bank_data["Interest Rates on Firm Deposits"] = initial_central_bank_policy_rate
         bank_data["Interest Rates on Household Deposits"] = initial_central_bank_policy_rate
@@ -358,7 +373,46 @@ class DefaultSyntheticBanks(SyntheticBanks):
         )
 
     @classmethod
-    def initialise_rates(cls, country_name, inflation_data, proxy_eu_country, quarter, readers, year):
+    @staticmethod
+    def _periods_per_year(time_unit: int) -> int:
+        """Return the number of model periods in one calendar year."""
+        if time_unit <= 0 or 12 % time_unit != 0:
+            raise ValueError("Bank-rate preprocessing requires `time_unit` to be a positive divisor of 12.")
+        return 12 // time_unit
+
+    @classmethod
+    def _convert_annual_rate_to_period(cls, annual_rate: float, time_unit: int) -> float:
+        """Convert an annual quoted rate to the model's per-period convention."""
+        return annual_rate / cls._periods_per_year(time_unit)
+
+    @classmethod
+    def _convert_annual_rate_series_to_period(cls, annual_rates: Optional[pd.Series], time_unit: int) -> Optional[pd.Series]:
+        """Convert a quoted annual rate series to per-period units."""
+        if annual_rates is None:
+            return None
+        return annual_rates.astype(float) / cls._periods_per_year(time_unit)
+
+    @classmethod
+    def _convert_annual_rate_frame_to_period(
+        cls,
+        annual_rates: pd.DataFrame,
+        time_unit: int,
+        column: str,
+    ) -> pd.DataFrame:
+        """Convert a quoted annual-rate column in a DataFrame to per-period units."""
+        period_rates = annual_rates.copy()
+        period_rates[column] = period_rates[column].astype(float) / cls._periods_per_year(time_unit)
+        return period_rates
+
+    @staticmethod
+    def _initial_policy_rate_quarter_key(year: int, quarter: int) -> str:
+        """Return the pre-start quarter key used for initial policy-rate anchoring."""
+        start_period = pd.Period(year=year, quarter=quarter, freq="Q")
+        initial_period = start_period - 1
+        return f"{initial_period.year}-Q{initial_period.quarter}"
+
+    @classmethod
+    def initialise_rates(cls, country_name, inflation_data, proxy_eu_country, quarter, readers, year, time_unit):
         """Preprocess and estimate initial interest rate parameters.
 
         This method:
@@ -379,6 +433,7 @@ class DefaultSyntheticBanks(SyntheticBanks):
             quarter (int): Reference quarter
             readers (DataReaders): Data source readers
             year (int): Reference year
+            time_unit (int): Simulation period length in months
 
         Returns:
             tuple: Nine estimated parameters:
@@ -398,10 +453,20 @@ class DefaultSyntheticBanks(SyntheticBanks):
             if proxy_eu_country is None:
                 raise ValueError("Proxy EU country is required for non-EU countries.")
             data_country = proxy_eu_country
-        firm_rate = readers.ecb_reader.get_firm_rates(data_country)
-        household_consumption_rate = readers.ecb_reader.get_household_consumption_rates(data_country)
-        household_mortgage_rates = readers.ecb_reader.get_household_mortgage_rates(data_country)
-        policy_rates = readers.policy_rates.get_policy_rates(data_country)
+        firm_rate = cls._convert_annual_rate_series_to_period(readers.ecb_reader.get_firm_rates(data_country), time_unit)
+        household_consumption_rate = cls._convert_annual_rate_series_to_period(
+            readers.ecb_reader.get_household_consumption_rates(data_country),
+            time_unit,
+        )
+        household_mortgage_rates = cls._convert_annual_rate_series_to_period(
+            readers.ecb_reader.get_household_mortgage_rates(data_country),
+            time_unit,
+        )
+        policy_rates = cls._convert_annual_rate_frame_to_period(
+            readers.policy_rates.get_policy_rates(data_country),
+            time_unit,
+            "Policy Rate",
+        )
         npl_rates = readers.world_bank.get_npl_ratios(data_country)
         if any(
             [

--- a/macro_data/processing/synthetic_banks/default_synthetic_banks.py
+++ b/macro_data/processing/synthetic_banks/default_synthetic_banks.py
@@ -427,7 +427,9 @@ class DefaultSyntheticBanks(SyntheticBanks):
             readers.ecb_reader.get_household_consumption_rates(data_country),
             time_unit,
         )
-        household_mortgage_rates = annual_to_period(readers.ecb_reader.get_household_mortgage_rates(data_country), time_unit)
+        household_mortgage_rates = annual_to_period(
+            readers.ecb_reader.get_household_mortgage_rates(data_country), time_unit
+        )
         policy_rates = annual_to_period(readers.policy_rates.get_policy_rates(data_country), time_unit, "Policy Rate")
         npl_rates = readers.world_bank.get_npl_ratios(data_country)
         if any(

--- a/macro_data/processing/synthetic_central_bank/default_synthetic_central_bank.py
+++ b/macro_data/processing/synthetic_central_bank/default_synthetic_central_bank.py
@@ -34,6 +34,7 @@ from macro_data.processing.synthetic_central_bank.synthetic_central_bank import 
 )
 from macro_data.readers.default_readers import DataReaders
 from macro_data.readers.exogenous_data import ExogenousCountryData
+from macro_data.util.frequency import periods_per_year
 
 
 class DefaultSyntheticCentralBank(SyntheticCentralBank):
@@ -194,26 +195,19 @@ class DefaultSyntheticCentralBank(SyntheticCentralBank):
         central_bank_data = pd.DataFrame(central_bank_data)
         return cls(country_name, year, central_bank_data)
 
-    @staticmethod
-    def _periods_per_year(time_unit: int) -> int:
-        """Return the number of model periods in one calendar year."""
-        if time_unit <= 0 or 12 % time_unit != 0:
-            raise ValueError("SmoothTaylorRule calibration requires `time_unit` to be a positive divisor of 12.")
-        return 12 // time_unit
-
     @classmethod
     def _compute_cpi_yoy_inflation(cls, cpi_inflation: pd.Series, time_unit: int) -> pd.Series:
         """Build a YoY CPI inflation series from per-period CPI inflation."""
-        periods_per_year = cls._periods_per_year(time_unit)
-        compounded = (1.0 + cpi_inflation.astype(float)).rolling(periods_per_year).apply(np.prod, raw=True)
+        periods_per_year_value = periods_per_year(time_unit)
+        compounded = (1.0 + cpi_inflation.astype(float)).rolling(periods_per_year_value).apply(np.prod, raw=True)
         return compounded - 1.0
 
     @classmethod
     def _compute_output_gap(cls, real_gross_output: pd.Series, time_unit: int) -> pd.Series:
         """Build an output-gap series using a one-year EWMA trend."""
-        periods_per_year = cls._periods_per_year(time_unit)
+        periods_per_year_value = periods_per_year(time_unit)
         safe_real_output = real_gross_output.astype(float).clip(lower=1e-12)
-        potential_output = safe_real_output.ewm(span=periods_per_year, adjust=False).mean().clip(lower=1e-12)
+        potential_output = safe_real_output.ewm(span=periods_per_year_value, adjust=False).mean().clip(lower=1e-12)
         return np.log(safe_real_output) - np.log(potential_output)
 
     @classmethod
@@ -273,7 +267,7 @@ class DefaultSyntheticCentralBank(SyntheticCentralBank):
         phi_pi = float(res.params[2] / (1 - rho))
         phi_q = float(res.params[3] / (1 - rho))
         r_star = float(res.params[0] / (1 - rho) - targeted_inflation_rate)
-        periods_per_year = cls._periods_per_year(time_unit)
+        periods_per_year_value = periods_per_year(time_unit)
 
         return {
             "rho": rho,
@@ -281,5 +275,5 @@ class DefaultSyntheticCentralBank(SyntheticCentralBank):
             "phi_pi": phi_pi,
             "phi_q": phi_q,
             # SmoothTaylorRule stores rates in per-period units inside the simulation.
-            "policy_rate": max(0.0, float(merged["Policy Rate"].values[-1]) / periods_per_year),
+            "policy_rate": max(0.0, float(merged["Policy Rate"].values[-1]) / periods_per_year_value),
         }

--- a/macro_data/processing/synthetic_central_bank/default_synthetic_central_bank.py
+++ b/macro_data/processing/synthetic_central_bank/default_synthetic_central_bank.py
@@ -102,6 +102,7 @@ class DefaultSyntheticCentralBank(SyntheticCentralBank):
         readers: DataReaders,
         exogenous_data: ExogenousCountryData,
         central_bank_configuration: CentralBankDataConfiguration,
+        time_unit: int,
     ):
         """Create a preprocessed central bank data container using historical data.
 
@@ -123,6 +124,8 @@ class DefaultSyntheticCentralBank(SyntheticCentralBank):
             readers (DataReaders): Data source readers
             exogenous_data (ExogenousCountryData): External economic data
             central_bank_configuration (CentralBankDataConfiguration): Configuration settings
+            time_unit (int): Simulation period length in months, used to build
+                one-year CPI YoY inflation and the output-gap trend.
 
         Returns:
             DefaultSyntheticCentralBank: Container with preprocessed parameters
@@ -157,30 +160,126 @@ class DefaultSyntheticCentralBank(SyntheticCentralBank):
         res = model.fit()
 
         # Extract and transform parameters
+        inflation_response = res.params[2] / (1 - res.params[1])
+        growth_response = res.params[3] / (1 - res.params[1])
+        smooth_taylor_params = cls._estimate_smooth_taylor_rule(
+            policy_rates=policy_rates,
+            exogenous_data=exogenous_data,
+            targeted_inflation_rate=targeted_inflation_rate,
+            year=year,
+            quarter=quarter,
+            time_unit=time_unit,
+        )
         central_bank_data = {
             "targeted_inflation_rate": [targeted_inflation_rate],
             "rho": [res.params[1]],  # Interest rate smoothing
             "r_star": [res.params[0] / (1 - res.params[1]) - targeted_inflation_rate],  # Natural rate
-            "xi_pi": [res.params[2] / (1 - res.params[1])],  # Inflation response
-            "xi_gamma": [res.params[3] / (1 - res.params[1])],  # Growth response
+            "xi_pi": [inflation_response],  # Poledna inflation response
+            "xi_gamma": [growth_response],  # Poledna growth response
+            "smooth_rho": [smooth_taylor_params["rho"]],
+            "smooth_r_star": [smooth_taylor_params["r_star"]],
+            "phi_pi": [smooth_taylor_params["phi_pi"]],
+            "phi_q": [smooth_taylor_params["phi_q"]],
+            "smooth_policy_rate": [smooth_taylor_params["policy_rate"]],
         }
 
         # TODO: the xi_pi factor is wrong
 
-        # Compute current policy rate with zero lower bound
-        central_bank_data["policy_rate"] = [
-            max(
-                0.0,  # Zero lower bound
-                central_bank_data["rho"][0] * merged["Policy Rate"].values[-1]
-                + (1 - central_bank_data["rho"][0])
-                * (
-                    central_bank_data["r_star"][0]
-                    + targeted_inflation_rate
-                    + central_bank_data["xi_pi"][0] * (excess_inflation[-1] - targeted_inflation_rate)
-                    + central_bank_data["xi_gamma"][0] * growth_values[-1]
-                ),
-            )
-        ]
+        # Keep the legacy Poledna initialization anchored to the last observed
+        # policy rate before the simulation start. This preserves a clear
+        # interpretation for the stored value even though the Poledna rule itself
+        # remains on its legacy convention.
+        central_bank_data["policy_rate"] = [max(0.0, float(merged["Policy Rate"].values[-1]))]
 
         central_bank_data = pd.DataFrame(central_bank_data)
         return cls(country_name, year, central_bank_data)
+
+    @staticmethod
+    def _periods_per_year(time_unit: int) -> int:
+        """Return the number of model periods in one calendar year."""
+        if time_unit <= 0 or 12 % time_unit != 0:
+            raise ValueError("SmoothTaylorRule calibration requires `time_unit` to be a positive divisor of 12.")
+        return 12 // time_unit
+
+    @classmethod
+    def _compute_cpi_yoy_inflation(cls, cpi_inflation: pd.Series, time_unit: int) -> pd.Series:
+        """Build a YoY CPI inflation series from per-period CPI inflation."""
+        periods_per_year = cls._periods_per_year(time_unit)
+        compounded = (1.0 + cpi_inflation.astype(float)).rolling(periods_per_year).apply(np.prod, raw=True)
+        return compounded - 1.0
+
+    @classmethod
+    def _compute_output_gap(cls, real_gross_output: pd.Series, time_unit: int) -> pd.Series:
+        """Build an output-gap series using a one-year EWMA trend."""
+        periods_per_year = cls._periods_per_year(time_unit)
+        safe_real_output = real_gross_output.astype(float).clip(lower=1e-12)
+        potential_output = safe_real_output.ewm(span=periods_per_year, adjust=False).mean().clip(lower=1e-12)
+        return np.log(safe_real_output) - np.log(potential_output)
+
+    @classmethod
+    def _estimate_smooth_taylor_rule(
+        cls,
+        policy_rates: pd.DataFrame,
+        exogenous_data: ExogenousCountryData,
+        targeted_inflation_rate: float,
+        year: int,
+        quarter: int,
+        time_unit: int,
+    ) -> dict[str, float]:
+        """Estimate SmoothTaylorRule parameters on annual policy rates.
+
+        The estimated regression is:
+
+            i_t = c + rho * i_{t-1} + beta_pi * (pi_t^yoy - pi*) + beta_q * q_t
+
+        where `pi_t^yoy` is YoY CPI inflation and `q_t` is the output gap. The
+        structural Taylor-rule coefficients are recovered by dividing the reduced-form
+        loadings by `(1 - rho)`.
+        """
+        cpi_yoy_inflation = cls._compute_cpi_yoy_inflation(exogenous_data.inflation["CPI Inflation"], time_unit)
+        output_gap = cls._compute_output_gap(exogenous_data.national_accounts["Real Gross Output (Value)"], time_unit)
+
+        merged = pd.merge_asof(
+            policy_rates.sort_index(),
+            cpi_yoy_inflation.rename("CPI YoY Inflation").sort_index(),
+            left_index=True,
+            right_index=True,
+        )
+        merged = pd.merge_asof(
+            merged,
+            output_gap.rename("Output Gap").sort_index(),
+            left_index=True,
+            right_index=True,
+        )
+        merged = merged.loc[merged.index < pd.to_datetime(f"{year}-Q{quarter}")]
+        merged = merged.dropna()
+
+        cpi_gap = merged["CPI YoY Inflation"].values.astype(float) - targeted_inflation_rate
+        exog = np.array(list(zip(cpi_gap, merged["Output Gap"].values.astype(float))))
+        order = {i: 0 for i in range(exog.shape[1])}
+
+        model = ARDL(
+            endog=merged["Policy Rate"].values.astype(float),
+            lags=1,
+            exog=exog,
+            order=order,
+            causal=False,
+            trend="c",
+            seasonal=False,
+        )
+        res = model.fit()
+
+        rho = float(res.params[1])
+        phi_pi = float(res.params[2] / (1 - rho))
+        phi_q = float(res.params[3] / (1 - rho))
+        r_star = float(res.params[0] / (1 - rho) - targeted_inflation_rate)
+        periods_per_year = cls._periods_per_year(time_unit)
+
+        return {
+            "rho": rho,
+            "r_star": r_star,
+            "phi_pi": phi_pi,
+            "phi_q": phi_q,
+            # SmoothTaylorRule stores rates in per-period units inside the simulation.
+            "policy_rate": max(0.0, float(merged["Policy Rate"].values[-1]) / periods_per_year),
+        }

--- a/macro_data/processing/synthetic_country.py
+++ b/macro_data/processing/synthetic_country.py
@@ -176,6 +176,7 @@ class SyntheticCountry:
         country: Country,
         year: int,
         quarter: int,
+        time_unit: int,
         country_configuration: CountryDataConfiguration,
         industries: list[str],
         readers: DataReaders,
@@ -199,6 +200,7 @@ class SyntheticCountry:
             country (Country): The EU country to create synthetic data for
             year (int): Base year for data generation
             quarter (int): Base quarter for data generation
+            time_unit (int): Simulation period length in months
             country_configuration (CountryDataConfiguration): Country-specific settings
             industries (list[str]): List of industry sectors to model
             readers (DataReaders): Data source readers
@@ -355,6 +357,7 @@ class SyntheticCountry:
         proxy_country: Country,
         year: int,
         quarter: int,
+        time_unit: int,
         country_configuration: CountryDataConfiguration,
         industries: list[str],
         readers: DataReaders,
@@ -381,6 +384,7 @@ class SyntheticCountry:
             proxy_country (Country): The EU country to use as a template
             year (int): Base year for data generation
             quarter (int): Base quarter for data generation
+            time_unit (int): Simulation period length in months
             country_configuration (CountryDataConfiguration): Country-specific settings
             industries (list[str]): List of industry sectors to model
             readers (DataReaders): Data source readers

--- a/macro_data/processing/synthetic_country.py
+++ b/macro_data/processing/synthetic_country.py
@@ -233,7 +233,13 @@ class SyntheticCountry:
         )
 
         central_bank = DefaultSyntheticCentralBank.from_readers(
-            country, year, quarter, readers, exogenous_country_data, country_configuration.central_bank_configuration
+            country,
+            year,
+            quarter,
+            readers,
+            exogenous_country_data,
+            country_configuration.central_bank_configuration,
+            time_unit=time_unit,
         )
 
         population: SyntheticHFCSPopulation = SyntheticHFCSPopulation.from_readers(
@@ -415,7 +421,13 @@ class SyntheticCountry:
         )
 
         central_bank = DefaultSyntheticCentralBank.from_readers(
-            country, year, quarter, readers, exogenous_country_data, country_configuration.central_bank_configuration
+            country,
+            year,
+            quarter,
+            readers,
+            exogenous_country_data,
+            country_configuration.central_bank_configuration,
+            time_unit=time_unit,
         )
 
         population_ratio = readers.world_bank.get_population(

--- a/macro_data/processing/synthetic_country.py
+++ b/macro_data/processing/synthetic_country.py
@@ -270,6 +270,7 @@ class SyntheticCountry:
             banks_data_configuration=country_configuration.banks_configuration,
             quarter=quarter,
             inflation_data=exogenous_country_data.inflation,
+            time_unit=time_unit,
         )
 
         synthetic_goods_market = SyntheticGoodsMarket.from_readers(
@@ -461,6 +462,7 @@ class SyntheticCountry:
             banks_data_configuration=country_configuration.banks_configuration,
             quarter=quarter,
             inflation_data=proxy_inflation_data,
+            time_unit=time_unit,
             proxy_eu_country=proxy_country,
         )
 

--- a/macro_data/util/frequency.py
+++ b/macro_data/util/frequency.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from numbers import Real
+
+import pandas as pd
+
+
+def periods_per_year(time_unit: int) -> int:
+    if time_unit <= 0 or 12 % time_unit != 0:
+        raise ValueError("time_unit must be a positive divisor of 12.")
+    return 12 // time_unit
+
+
+def annual_to_period(
+    value: Real | pd.Series | pd.DataFrame,
+    time_unit: int,
+    column: str | None = None,
+):
+    factor = periods_per_year(time_unit)
+
+    if isinstance(value, pd.DataFrame):
+        converted = value.copy()
+        if column is None:
+            return converted / factor
+        converted[column] = converted[column].astype(float) / factor
+        return converted
+
+    if isinstance(value, pd.Series):
+        return value.astype(float) / factor
+
+    if isinstance(value, Real) and not isinstance(value, bool):
+        return float(value) / factor
+
+    raise TypeError(f"Unsupported value type for annual-to-period conversion: {type(value)!r}")

--- a/macromodel/agents/central_bank/central_bank.py
+++ b/macromodel/agents/central_bank/central_bank.py
@@ -119,17 +119,36 @@ class CentralBank(Agent):
         functions = functions_from_model(model=configuration.functions, loc="macromodel.agents.central_bank")
 
         data = synthetic_central_bank.central_bank_data.astype(float).rename_axis("Central Bank ID")
+        policy_rule_name = configuration.functions.policy_rate.name
+
+        uses_smooth_taylor_rule = policy_rule_name == "SmoothTaylorRule" and {
+            "smooth_policy_rate",
+            "smooth_rho",
+            "smooth_r_star",
+        }.issubset(data.columns)
+
+        if uses_smooth_taylor_rule:
+            selected_data = data.copy()
+            selected_data["policy_rate"] = selected_data["smooth_policy_rate"]
+            selected_rho = data["smooth_rho"].values[0]
+            selected_r_star = data["smooth_r_star"].values[0]
+        else:
+            selected_data = data
+            selected_rho = data["rho"].values[0]
+            selected_r_star = data["r_star"].values[0]
 
         # Create the corresponding time series object
-        ts = create_central_bank_timeseries(data)
+        ts = create_central_bank_timeseries(selected_data)
 
         # Initialize monetary policy parameters
         states: dict[str, float | np.ndarray | list[np.ndarray]] = {
             "targeted_inflation_rate": data["targeted_inflation_rate"].values[0],
-            "rho": data["rho"].values[0],
-            "r_star": data["r_star"].values[0],
+            "rho": selected_rho,
+            "r_star": selected_r_star,
             "xi_pi": data["xi_pi"].values[0],
             "xi_gamma": data["xi_gamma"].values[0],
+            "phi_pi": (data["phi_pi"].values[0] if "phi_pi" in data.columns else data["xi_pi"].values[0]),
+            "phi_q": (data["phi_q"].values[0] if "phi_q" in data.columns else data["xi_gamma"].values[0]),
         }
 
         return cls(
@@ -154,7 +173,15 @@ class CentralBank(Agent):
         self.gen_reset()
         update_functions(model=configuration.functions, loc="macromodel.agents.central_bank", functions=self.functions)
 
-    def compute_rate(self, inflation: float, growth: float) -> float:
+    def compute_rate(
+        self,
+        inflation: float,
+        growth: float,
+        cpi_yoy_inflation: float | None = None,
+        output_gap: float | None = None,
+        time_unit: int = 1,
+        shock: float = 0.0,
+    ) -> float:
         """Calculate the policy interest rate.
 
         Determines appropriate policy rate based on:
@@ -166,6 +193,11 @@ class CentralBank(Agent):
         Args:
             inflation (float): Current inflation rate
             growth (float): Current economic growth rate
+            cpi_yoy_inflation (float | None): Optional year-over-year CPI inflation
+                used by Taylor-style rules that target annual CPI inflation.
+            output_gap (float | None): Optional output-gap measure.
+            time_unit (int): Simulation period length in months.
+            shock (float): Additive policy shock.
 
         Returns:
             float: New policy interest rate
@@ -175,6 +207,10 @@ class CentralBank(Agent):
             inflation=inflation,
             growth=growth,
             central_bank_states=self.states,
+            cpi_yoy_inflation=cpi_yoy_inflation,
+            output_gap=output_gap,
+            time_unit=time_unit,
+            shock=shock,
         )
 
     def save_to_h5(self, group: h5py.Group):

--- a/macromodel/agents/central_bank/func/policy_rate.py
+++ b/macromodel/agents/central_bank/func/policy_rate.py
@@ -226,8 +226,7 @@ class SmoothTaylorRule(PolicyRate):
             * (
                 central_bank_states["r_star"]
                 + central_bank_states["targeted_inflation_rate"]
-                + central_bank_states["phi_pi"]
-                * (annual_inflation - central_bank_states["targeted_inflation_rate"])
+                + central_bank_states["phi_pi"] * (annual_inflation - central_bank_states["targeted_inflation_rate"])
                 + central_bank_states["phi_q"] * current_output_gap
             )
             + shock

--- a/macromodel/agents/central_bank/func/policy_rate.py
+++ b/macromodel/agents/central_bank/func/policy_rate.py
@@ -41,6 +41,10 @@ class PolicyRate(ABC):
         inflation: float,
         growth: float,
         central_bank_states: dict[str, float],
+        cpi_yoy_inflation: float | None = None,
+        output_gap: float | None = None,
+        time_unit: int = 1,
+        shock: float = 0.0,
     ) -> float:
         """Calculate the appropriate policy interest rate.
 
@@ -60,6 +64,12 @@ class PolicyRate(ABC):
                 - r_star: Natural real interest rate
                 - xi_pi: Inflation gap response coefficient
                 - xi_gamma: Output growth response coefficient
+            cpi_yoy_inflation (float | None): Optional year-over-year CPI inflation
+                used by rules that target annual CPI inflation directly.
+            output_gap (float | None): Optional output gap used by rules that react
+                to activity relative to trend rather than raw growth.
+            time_unit (int): Simulation period length in months.
+            shock (float): Additive policy shock.
 
         Returns:
             float: New policy interest rate
@@ -88,6 +98,10 @@ class ConstantPolicyRate(PolicyRate):
         inflation: float,
         growth: float,
         central_bank_states: dict[str, float],
+        cpi_yoy_inflation: float | None = None,
+        output_gap: float | None = None,
+        time_unit: int = 1,
+        shock: float = 0.0,
     ) -> float:
         """Keep policy rate constant.
 
@@ -125,6 +139,10 @@ class PolednaPolicyRate(PolicyRate):
         inflation: float,
         growth: float,
         central_bank_states: dict[str, float],
+        cpi_yoy_inflation: float | None = None,
+        output_gap: float | None = None,
+        time_unit: int = 1,
+        shock: float = 0.0,
     ) -> float:
         """Calculate policy rate using Poledna et al. rule.
 
@@ -152,3 +170,66 @@ class PolednaPolicyRate(PolicyRate):
                 + central_bank_states["xi_gamma"] * growth
             ),
         )
+
+
+class SmoothTaylorRule(PolicyRate):
+    """Implementation of a smoothed Taylor rule with annual CPI inflation.
+
+    This rule follows:
+
+        i_t = rho * i_{t-1}
+            + (1-rho) * (r_star + pi_star + phi_pi * (pi_t - pi_star) + phi_q * q_t)
+            + epsilon_t
+
+    Design choices for this model implementation:
+    - `pi_t` is observed year-over-year CPI inflation.
+    - `r_star`, `targeted_inflation_rate`, `phi_pi`, and `phi_q` are interpreted as
+      annual-policy parameters.
+    - The model stores and applies policy rates in per-period units, so the final
+      annual policy rate is converted to the simulation frequency using `time_unit`.
+    """
+
+    @staticmethod
+    def _periods_per_year(time_unit: int) -> int:
+        """Convert the model time unit in months to integer periods per year."""
+        if time_unit <= 0 or 12 % time_unit != 0:
+            raise ValueError("SmoothTaylorRule requires `time_unit` to be a positive divisor of 12.")
+        return 12 // time_unit
+
+    def compute_rate(
+        self,
+        prev_rate: float,
+        inflation: float,
+        growth: float,
+        central_bank_states: dict[str, float],
+        cpi_yoy_inflation: float | None = None,
+        output_gap: float | None = None,
+        time_unit: int = 1,
+        shock: float = 0.0,
+    ) -> float:
+        """Calculate the per-period policy rate from annual Taylor-rule inputs.
+
+        Args:
+            [same as parent class]
+
+        Returns:
+            float: New policy rate in per-period units, constrained to be non-negative.
+        """
+        periods_per_year = self._periods_per_year(time_unit)
+        annual_prev_rate = prev_rate * periods_per_year
+        annual_inflation = inflation if cpi_yoy_inflation is None else cpi_yoy_inflation
+        current_output_gap = 0.0 if output_gap is None else output_gap
+
+        annual_rate = (
+            central_bank_states["rho"] * annual_prev_rate
+            + (1 - central_bank_states["rho"])
+            * (
+                central_bank_states["r_star"]
+                + central_bank_states["targeted_inflation_rate"]
+                + central_bank_states["phi_pi"]
+                * (annual_inflation - central_bank_states["targeted_inflation_rate"])
+                + central_bank_states["phi_q"] * current_output_gap
+            )
+            + shock
+        )
+        return max(0.0, annual_rate / periods_per_year)

--- a/macromodel/configurations/central_bank_configuration.py
+++ b/macromodel/configurations/central_bank_configuration.py
@@ -17,12 +17,13 @@ class CentralBankPolicy(BaseModel):
 
     Attributes:
         path_name (str): Module path for policy rate functions
-        name (Literal): Selected policy mechanism ("ConstantPolicyRate" or "PolednaPolicyRate")
+        name (Literal): Selected policy mechanism ("ConstantPolicyRate",
+            "PolednaPolicyRate", or "SmoothTaylorRule")
         parameters (dict): Configuration parameters for policy implementation
     """
 
     path_name: str = "policy_rate"
-    name: Literal["ConstantPolicyRate", "PolednaPolicyRate"] = "ConstantPolicyRate"
+    name: Literal["ConstantPolicyRate", "PolednaPolicyRate", "SmoothTaylorRule"] = "ConstantPolicyRate"
     parameters: dict = {}
 
 

--- a/macromodel/country/country.py
+++ b/macromodel/country/country.py
@@ -219,6 +219,7 @@ class Country:
         industries: list[str],
         initial_year: int,
         t_max: int,
+        time_unit: int,
         running_multiple_countries: bool,
         emission_factors_usd: np.ndarray,
     ) -> "Country":
@@ -236,6 +237,7 @@ class Country:
             industries (list[str]): Industry sectors
             initial_year (int): Starting year
             t_max (int): Maximum simulation periods
+            time_unit (int): Simulation period length in months
             running_multiple_countries (bool): If True, part of multi-country sim
             emission_factors_usd (np.ndarray): Emission factors in USD
 
@@ -357,6 +359,7 @@ class Country:
             households=households,
             industry_vectors=synthetic_country.industry_data["industry_vectors"],
             exogenous=exogenous,
+            time_unit=time_unit,
         )
 
         labour_market = LabourMarket.from_agents(
@@ -581,6 +584,9 @@ class Country:
                 self.central_bank.compute_rate(
                     inflation=self.economy.ts.current("ppi_inflation")[0],
                     growth=self.economy.ts.current("total_growth")[0],
+                    cpi_yoy_inflation=self.economy.ts.current("cpi_yoy_inflation")[0],
+                    output_gap=self.economy.ts.current("output_gap")[0],
+                    time_unit=self.economy.time_unit,
                 )
             ]
         )
@@ -1031,6 +1037,9 @@ class Country:
             firms_real_amount_bought_as_capital_goods=self.firms.ts.current("real_amount_bought_as_capital_goods"),
         )
         self.economy.compute_inflation()
+        self.economy.compute_cpi_yoy_inflation(
+            exogenous_cpi_inflation_before=self.exogenous.inflation_before["CPI Inflation"].values
+        )
         self.economy.compute_growth(
             current_production=self.firms.ts.current("production"),
             prev_production=self.firms.ts.prev("production"),
@@ -1280,6 +1289,9 @@ class Country:
                 central_bank_policy_rate=self.central_bank.ts.current("policy_rate"),
             )
         )
+        self.banks.ts.interest_received.append(
+            self.banks.ts.current("interest_received_on_loans") + self.banks.ts.current("interest_received_on_deposits")
+        )
         self.banks.ts.profits.append(self.banks.compute_profits())
         self.banks.ts.profits_histogram.append(get_histogram(self.banks.ts.current("profits"), self.scale))
 
@@ -1389,6 +1401,7 @@ class Country:
             central_government_rent_received=self.central_government.ts.current("total_rent_received")[0],
             running_multiple_countries=self.running_multiple_countries,
         )
+        self.economy.compute_output_gap()
 
     def update_population_structure(self) -> None:
         """Update demographic composition.
@@ -1460,8 +1473,10 @@ class Country:
             "Exports": self.economy.total_exports(),
             "PPI": self.economy.total_ppi_inflation(),
             "CPI": self.economy.total_cpi_inflation(),
+            "CPI YoY Inflation": self.economy.ts.get_aggregate("cpi_yoy_inflation"),
             "CFPI": self.economy.total_cfpi_inflation(),
             "Gross Output": self.firms.total_sales() + self.firms.total_taxes_paid_on_production(),
+            "Output Gap": self.economy.ts.get_aggregate("output_gap"),
             "Unemployment Rate": self.economy.unemployment_rate(),
             "Consumption Expansion Loan Debt": self.households.consumption_loan_debt(),
             "Mortgage Debt": self.households.mortgage_debt(),

--- a/macromodel/country/regional_aggregator.py
+++ b/macromodel/country/regional_aggregator.py
@@ -14,18 +14,30 @@ class RegionalAggregator:
     def sync_central_banks(self, countries: dict[str, Country]):
         """Synchronize the central banks of the countries in the aggregation structure."""
         for country, regions in self.aggregation_structure.items():
-            outputs = np.array([countries[region].economy.ts.current("total_output") for region in regions])
+            outputs = np.array([countries[region].economy.ts.current("total_output")[0] for region in regions])
             weights = outputs / np.sum(outputs)
 
             inflation_rates = np.array([countries[region].economy.ts.current("ppi_inflation")[0] for region in regions])
             total_growth_rates = np.array(
                 [countries[region].economy.ts.current("total_growth")[0] for region in regions]
             )
+            cpi_yoy_inflation_rates = np.array(
+                [countries[region].economy.ts.current("cpi_yoy_inflation")[0] for region in regions]
+            )
+            output_gaps = np.array([countries[region].economy.ts.current("output_gap")[0] for region in regions])
 
             avg_inflation = np.sum(weights * inflation_rates)
             avg_growth = np.sum(weights * total_growth_rates)
+            avg_cpi_yoy_inflation = np.sum(weights * cpi_yoy_inflation_rates)
+            avg_output_gap = np.sum(weights * output_gaps)
 
-            policy_rate = countries[regions[0]].central_bank.compute_rate(inflation=avg_inflation, growth=avg_growth)
+            policy_rate = countries[regions[0]].central_bank.compute_rate(
+                inflation=avg_inflation,
+                growth=avg_growth,
+                cpi_yoy_inflation=avg_cpi_yoy_inflation,
+                output_gap=avg_output_gap,
+                time_unit=countries[regions[0]].economy.time_unit,
+            )
 
             for region in regions:
                 countries[region].central_bank.ts.override_current("policy_rate", [policy_rate])

--- a/macromodel/economy/economy.py
+++ b/macromodel/economy/economy.py
@@ -734,9 +734,7 @@ class Economy:
         alpha = 2.0 / (periods_per_year + 1.0)
         current_real_gross_output = self.ts.current("total_output")[0] / np.maximum(self.ts.current("ppi")[0], 1e-12)
         previous_potential_output = self.ts.current("potential_output")[0]
-        current_potential_output = (
-            alpha * current_real_gross_output + (1.0 - alpha) * previous_potential_output
-        )
+        current_potential_output = alpha * current_real_gross_output + (1.0 - alpha) * previous_potential_output
         safe_real_output = np.maximum(current_real_gross_output, 1e-12)
         safe_potential_output = np.maximum(current_potential_output, 1e-12)
 

--- a/macromodel/economy/economy.py
+++ b/macromodel/economy/economy.py
@@ -116,6 +116,7 @@ class Economy:
         n_industries: int,
         functions: dict[str, Any],
         ts: TimeSeries,
+        time_unit: int,
     ):
         """Initialize an Economy instance.
 
@@ -125,6 +126,7 @@ class Economy:
             n_industries (int): Number of industrial sectors
             functions (dict[str, Any]): Economic function implementations
             ts (TimeSeries): Time series data for economic metrics
+            time_unit (int): Simulation period length in months
         """
         self.country_name = country_name
         self.all_country_names = all_country_names
@@ -132,6 +134,7 @@ class Economy:
         self.functions = functions
         self.n_industries = n_industries
         self.ts = ts
+        self.time_unit = time_unit
 
     @classmethod
     def from_agents(
@@ -146,6 +149,7 @@ class Economy:
         central_government: CentralGovernment,
         exogenous: Exogenous,
         industry_vectors: pd.DataFrame,
+        time_unit: int,
     ):
         """Create an Economy instance from agent-level data and configurations.
 
@@ -170,6 +174,7 @@ class Economy:
             central_government (CentralGovernment): Fiscal authority
             exogenous (Exogenous): External economic conditions
             industry_vectors (pd.DataFrame): Industry-level initial conditions
+            time_unit (int): Simulation period length in months
 
         Returns:
             Economy: Newly constructed Economy instance with initialized metrics
@@ -251,6 +256,14 @@ class Economy:
         export_taxes = central_government.states["Export Tax"]
 
         initial_npl_ratio = 0.0
+        periods_per_year = cls._periods_per_year(time_unit)
+        initial_cpi_yoy_inflation = cls._compute_yoy_from_period_inflation(
+            np.concatenate((exogenous.inflation_before["CPI Inflation"].values, np.array([initial_cpi_inflation]))),
+            periods_per_year,
+        )
+        initial_real_gross_output = initial_total_output
+        initial_potential_output = initial_real_gross_output
+        initial_output_gap = 0.0
 
         ts = create_economy_timeseries(
             country_name=country_name,
@@ -268,6 +281,7 @@ class Economy:
             initial_total_wages=initial_total_wages,
             initial_individual_activity=initial_individual_activity,
             initial_cpi_inflation=initial_cpi_inflation,
+            initial_cpi_yoy_inflation=initial_cpi_yoy_inflation,
             initial_ppi_inflation=initial_ppi_inflation,
             initial_hpi_inflation=initial_hpi_inflation,
             initial_real_rent_paid=initial_real_rent_paid,
@@ -284,6 +298,9 @@ class Economy:
             initial_total_growth=initial_total_growth[0],
             export_taxes=export_taxes,
             initial_npl_ratio=initial_npl_ratio,
+            initial_real_gross_output=initial_real_gross_output,
+            initial_potential_output=initial_potential_output,
+            initial_output_gap=initial_output_gap,
         )
 
         functions = functions_from_model(economy_configuration.functions, loc="macromodel.economy")
@@ -296,7 +313,29 @@ class Economy:
             n_industries,
             functions,
             ts,
+            time_unit,
         )
+
+    @staticmethod
+    def _periods_per_year(time_unit: int) -> int:
+        """Return the number of model periods in one year.
+
+        The YoY CPI measure and the one-year EWMA trend both require the simulation
+        frequency to divide evenly into a calendar year.
+        """
+        if time_unit <= 0 or 12 % time_unit != 0:
+            raise ValueError("Economy time-based policy helpers require `time_unit` to be a positive divisor of 12.")
+        return 12 // time_unit
+
+    @staticmethod
+    def _compute_yoy_from_period_inflation(period_inflation: np.ndarray, periods_per_year: int) -> float:
+        """Convert a history of per-period inflation rates into a YoY rate."""
+        clean_inflation = period_inflation[~np.isnan(period_inflation)]
+        if clean_inflation.size == 0:
+            return 0.0
+        if clean_inflation.size < periods_per_year:
+            return clean_inflation[-1]
+        return float(np.prod(1.0 + clean_inflation[-periods_per_year:]) - 1.0)
 
     def reset(self, configuration: EconomyConfiguration) -> None:
         """Reset the economy's state and update function configurations.
@@ -628,6 +667,23 @@ class Economy:
             inflation_by_industry[g] = self.ts.current("good_prices")[g] / self.ts.prev("good_prices")[g] - 1.0
         self.ts.industry_inflation.append(inflation_by_industry)
 
+    def compute_cpi_yoy_inflation(self, exogenous_cpi_inflation_before: np.ndarray) -> None:
+        """Calculate CPI inflation over one year using per-period CPI inflation history.
+
+        The policy rule consumes a smoother annual CPI signal. Rather than rebuilding
+        historical CPI levels, this method compounds the latest `periods_per_year`
+        period-over-period CPI inflation rates from the combined exogenous and
+        endogenous histories.
+        """
+        periods_per_year = self._periods_per_year(self.time_unit)
+        combined_history = np.concatenate(
+            (
+                exogenous_cpi_inflation_before,
+                np.array(self.ts.historic("cpi_inflation")).flatten(),
+            )
+        )
+        self.ts.cpi_yoy_inflation.append([self._compute_yoy_from_period_inflation(combined_history, periods_per_year)])
+
     def compute_growth(
         self,
         current_production: np.ndarray,
@@ -666,6 +722,27 @@ class Economy:
             else:
                 current_sectoral_growth[g] = (current_total_output - prev_total_output) / prev_total_output
         self.ts.sectoral_growth.append(current_sectoral_growth)
+
+    def compute_output_gap(self) -> None:
+        """Update the real-output trend and output gap used by SmoothTaylorRule.
+
+        Real gross output is approximated using total nominal output deflated by the
+        current PPI index. Potential output is a one-sided EWMA trend with a span of
+        one model year, which keeps the implementation simple and frequency-aware.
+        """
+        periods_per_year = self._periods_per_year(self.time_unit)
+        alpha = 2.0 / (periods_per_year + 1.0)
+        current_real_gross_output = self.ts.current("total_output")[0] / np.maximum(self.ts.current("ppi")[0], 1e-12)
+        previous_potential_output = self.ts.current("potential_output")[0]
+        current_potential_output = (
+            alpha * current_real_gross_output + (1.0 - alpha) * previous_potential_output
+        )
+        safe_real_output = np.maximum(current_real_gross_output, 1e-12)
+        safe_potential_output = np.maximum(current_potential_output, 1e-12)
+
+        self.ts.real_gross_output.append([current_real_gross_output])
+        self.ts.potential_output.append([current_potential_output])
+        self.ts.output_gap.append([np.log(safe_real_output) - np.log(safe_potential_output)])
 
     def compute_house_price_index(
         self,

--- a/macromodel/economy/economy_ts.py
+++ b/macromodel/economy/economy_ts.py
@@ -63,6 +63,7 @@ def create_economy_timeseries(
     initial_total_wages: float,
     initial_individual_activity: np.ndarray,
     initial_cpi_inflation: float,
+    initial_cpi_yoy_inflation: float,
     initial_ppi_inflation: float,
     initial_hpi_inflation: float,
     initial_real_rent_paid: np.ndarray,
@@ -79,6 +80,9 @@ def create_economy_timeseries(
     export_taxes: float,
     initial_total_growth: float,
     initial_npl_ratio: float,
+    initial_real_gross_output: float,
+    initial_potential_output: float,
+    initial_output_gap: float,
 ) -> TimeSeries:
     """Create and initialize economy-wide time series data.
 
@@ -111,6 +115,7 @@ def create_economy_timeseries(
         initial_total_wages (float): Total wage payments
         initial_individual_activity (np.ndarray): Activity statuses
         initial_cpi_inflation (float): Starting CPI inflation
+        initial_cpi_yoy_inflation (float): Starting year-over-year CPI inflation
         initial_ppi_inflation (float): Starting PPI inflation
         initial_hpi_inflation (float): Starting HPI inflation
         initial_real_rent_paid (np.ndarray): Actual rent payments
@@ -127,6 +132,9 @@ def create_economy_timeseries(
         export_taxes (float): Export tax rate
         initial_total_growth (float): Starting growth rate
         initial_npl_ratio (float): Non-performing loan ratio
+        initial_real_gross_output (float): Starting real gross output level
+        initial_potential_output (float): Starting smoothed real gross output trend
+        initial_output_gap (float): Starting output gap
 
     Returns:
         TimeSeries: Initialized time series object with all economic indicators
@@ -139,6 +147,7 @@ def create_economy_timeseries(
         initial_price=[initial_firm_prices],
         #
         cpi_inflation=[initial_cpi_inflation],
+        cpi_yoy_inflation=[initial_cpi_yoy_inflation],
         ppi_inflation=[initial_ppi_inflation],
         cfpi_inflation=[np.nan],
         industry_inflation=np.full(n_industries, np.nan),
@@ -177,6 +186,9 @@ def create_economy_timeseries(
         total_growth=[initial_total_growth],
         estimated_growth=[np.nan],
         sectoral_growth=np.full(n_industries, np.nan),
+        real_gross_output=[initial_real_gross_output],
+        potential_output=[initial_potential_output],
+        output_gap=[initial_output_gap],
         #
         hpi=[1.0],
         hpi_inflation=[initial_hpi_inflation],

--- a/macromodel/simulation.py
+++ b/macromodel/simulation.py
@@ -141,6 +141,7 @@ class Simulation:
                 industries=datawrapper.industries,
                 initial_year=datawrapper.configuration.year,
                 t_max=simulation_configuration.t_max,
+                time_unit=datawrapper.time_unit,
                 running_multiple_countries=running_multi_country,
                 emission_factors_usd=emission_factors,
             )

--- a/tests/test_macro_data/unit/test_processing/test_synthetic_banks/test_synthetic_banks.py
+++ b/tests/test_macro_data/unit/test_processing/test_synthetic_banks/test_synthetic_banks.py
@@ -24,6 +24,7 @@ class TestSyntheticBanks:
             banks_data_configuration=banks_configuration,
             quarter=1,
             inflation_data=exogenous_data.inflation,
+            time_unit=3,
         )
         # banks.create(
         #     bank_equity=1000,
@@ -60,6 +61,9 @@ class TestSyntheticBanks:
         }
 
         assert set(banks.bank_data.columns) == columns
+        annual_policy_rate = readers.policy_rates.get_policy_rates(Country("FRA")).loc["2013-Q4", "Policy Rate"].values[0]
+        assert banks.bank_data["Interest Rates on Firm Deposits"].values[0] == annual_policy_rate / 4.0
+        assert banks.bank_data["Interest Rates on Household Deposits"].values[0] == annual_policy_rate / 4.0
         # Check if we have all the necessary fields
         # for bank_field in [
         #     "Equity",

--- a/tests/test_macro_data/unit/test_processing/test_synthetic_banks/test_synthetic_banks.py
+++ b/tests/test_macro_data/unit/test_processing/test_synthetic_banks/test_synthetic_banks.py
@@ -61,7 +61,9 @@ class TestSyntheticBanks:
         }
 
         assert set(banks.bank_data.columns) == columns
-        annual_policy_rate = readers.policy_rates.get_policy_rates(Country("FRA")).loc["2013-Q4", "Policy Rate"].values[0]
+        annual_policy_rate = (
+            readers.policy_rates.get_policy_rates(Country("FRA")).loc["2013-Q4", "Policy Rate"].values[0]
+        )
         assert banks.bank_data["Interest Rates on Firm Deposits"].values[0] == annual_policy_rate / 4.0
         assert banks.bank_data["Interest Rates on Household Deposits"].values[0] == annual_policy_rate / 4.0
         # Check if we have all the necessary fields

--- a/tests/test_macro_data/unit/test_processing/test_synthetic_central_banks/test_synthetic_central_banks.py
+++ b/tests/test_macro_data/unit/test_processing/test_synthetic_central_banks/test_synthetic_central_banks.py
@@ -22,11 +22,16 @@ class TestSyntheticCentralBanks:
             quarter=1,
             central_bank_configuration=central_bank_config,
             exogenous_data=exogenous_data,
+            time_unit=3,
         )
 
         # Check if we have all the necessary fields
-        for central_bank_field in ["policy_rate"]:
+        for central_bank_field in ["policy_rate", "smooth_policy_rate", "smooth_rho", "smooth_r_star", "phi_pi", "phi_q"]:
             assert central_bank_field in central_banks.central_bank_data.columns
+
+        annual_policy_rate = readers.policy_rates.get_policy_rates("FRA").loc["2013-Q4", "Policy Rate"].values[0]
+        assert central_banks.central_bank_data["policy_rate"].values[0] == annual_policy_rate
+        assert central_banks.central_bank_data["smooth_policy_rate"].values[0] == annual_policy_rate / 4.0
 
         # Check if there are any missing values
         assert not np.any(pd.isna(central_banks.central_bank_data))

--- a/tests/test_macro_data/unit/test_processing/test_synthetic_central_banks/test_synthetic_central_banks.py
+++ b/tests/test_macro_data/unit/test_processing/test_synthetic_central_banks/test_synthetic_central_banks.py
@@ -26,7 +26,14 @@ class TestSyntheticCentralBanks:
         )
 
         # Check if we have all the necessary fields
-        for central_bank_field in ["policy_rate", "smooth_policy_rate", "smooth_rho", "smooth_r_star", "phi_pi", "phi_q"]:
+        for central_bank_field in [
+            "policy_rate",
+            "smooth_policy_rate",
+            "smooth_rho",
+            "smooth_r_star",
+            "phi_pi",
+            "phi_q",
+        ]:
             assert central_bank_field in central_banks.central_bank_data.columns
 
         annual_policy_rate = readers.policy_rates.get_policy_rates("FRA").loc["2013-Q4", "Policy Rate"].values[0]

--- a/tests/test_macro_data/unit/test_util/test_frequency.py
+++ b/tests/test_macro_data/unit/test_util/test_frequency.py
@@ -1,0 +1,48 @@
+import pandas as pd
+import pytest
+
+from macro_data.util.frequency import annual_to_period, periods_per_year
+
+
+class TestPeriodsPerYear:
+    @pytest.mark.parametrize(
+        ("time_unit", "expected"),
+        [(1, 12), (2, 6), (3, 4), (4, 3), (6, 2), (12, 1)],
+    )
+    def test_valid_divisors(self, time_unit, expected):
+        assert periods_per_year(time_unit) == expected
+
+    @pytest.mark.parametrize("time_unit", [0, 5, 7, 10, 13])
+    def test_invalid_time_unit(self, time_unit):
+        with pytest.raises(ValueError):
+            periods_per_year(time_unit)
+
+
+class TestAnnualToPeriod:
+    def test_scalar_conversion(self):
+        assert annual_to_period(0.12, 3) == pytest.approx(0.03)
+
+    def test_series_conversion(self):
+        series = pd.Series([0.12, 0.24], index=["a", "b"])
+        expected = pd.Series([0.03, 0.06], index=["a", "b"])
+        pd.testing.assert_series_equal(annual_to_period(series, 3), expected)
+
+    def test_dataframe_conversion_all_numeric_columns(self):
+        frame = pd.DataFrame({"Policy Rate": [0.12, 0.24], "Other Rate": [0.06, 0.18]})
+        expected = pd.DataFrame({"Policy Rate": [0.03, 0.06], "Other Rate": [0.015, 0.045]})
+        pd.testing.assert_frame_equal(annual_to_period(frame, 3), expected)
+
+    def test_dataframe_conversion_target_column(self):
+        frame = pd.DataFrame(
+            {
+                "Policy Rate": [0.12, 0.24],
+                "Other Rate": [0.06, 0.18],
+            }
+        )
+        expected = pd.DataFrame(
+            {
+                "Policy Rate": [0.03, 0.06],
+                "Other Rate": [0.06, 0.18],
+            }
+        )
+        pd.testing.assert_frame_equal(annual_to_period(frame, 3, "Policy Rate"), expected)

--- a/tests/test_macromodel/unit/conftest.py
+++ b/tests/test_macromodel/unit/conftest.py
@@ -233,6 +233,7 @@ def test_economy(
         central_government=test_central_government,
         exogenous=test_exogenous,
         industry_vectors=synthetic_country.industry_data["industry_vectors"],
+        time_unit=3,
     )
 
 

--- a/tests/test_macromodel/unit/default_unit_test.yaml
+++ b/tests/test_macromodel/unit/default_unit_test.yaml
@@ -72,7 +72,7 @@ FRA:
       policy_rate:
         name:
           desc: The function used for setting the central bank policy rate.
-          options: ConstantPolicyRate,PolednaPolicyRate
+          options: ConstantPolicyRate,PolednaPolicyRate,SmoothTaylorRule
           type: str
           value: PolednaPolicyRate
   central_government:

--- a/tests/test_macromodel/unit/test_agents/test_central_bank/func/test_policy_rate.py
+++ b/tests/test_macromodel/unit/test_agents/test_central_bank/func/test_policy_rate.py
@@ -1,4 +1,6 @@
-from macromodel.agents.central_bank.func.policy_rate import ConstantPolicyRate
+import pytest
+
+from macromodel.agents.central_bank.func.policy_rate import ConstantPolicyRate, SmoothTaylorRule
 
 
 class TestPolicyRate:
@@ -12,3 +14,23 @@ class TestPolicyRate:
             )
             == 0.01
         )
+
+    def test__smooth_taylor_rule_converts_annual_rate_to_period_rate(self):
+        rate = SmoothTaylorRule().compute_rate(
+            prev_rate=0.01,
+            inflation=0.03,
+            growth=0.0,
+            central_bank_states={
+                "rho": 0.5,
+                "r_star": 0.02,
+                "targeted_inflation_rate": 0.02,
+                "phi_pi": 1.5,
+                "phi_q": 0.5,
+            },
+            cpi_yoy_inflation=0.03,
+            output_gap=0.02,
+            time_unit=3,
+        )
+
+        # Annual rate = 0.5 * 0.04 + 0.5 * (0.02 + 0.02 + 1.5 * 0.01 + 0.5 * 0.02) = 0.0525
+        assert rate == pytest.approx(0.0525 / 4.0)

--- a/tests/test_macromodel/unit/test_agents/test_economy/test_economy.py
+++ b/tests/test_macromodel/unit/test_agents/test_economy/test_economy.py
@@ -1,3 +1,7 @@
+import numpy as np
+import pytest
+
+
 class TestEconomy:
     def test__economy_states(self, test_economy):
         assert test_economy is not None
@@ -15,5 +19,31 @@ class TestEconomy:
             "bank_insolvency_rate",
             "household_insolvency_rate",
             "total_growth",
+            "cpi_yoy_inflation",
+            "potential_output",
+            "output_gap",
         ]:
             assert ts_key in test_economy.ts.get_keys()
+
+    def test__compute_cpi_yoy_inflation(self, test_economy):
+        test_economy.ts.dicts["cpi_inflation"] = [[0.01], [0.02], [0.03], [0.04]]
+
+        test_economy.compute_cpi_yoy_inflation(exogenous_cpi_inflation_before=np.array([]))
+
+        expected = np.prod([1.01, 1.02, 1.03, 1.04]) - 1.0
+        assert test_economy.ts.current("cpi_yoy_inflation")[0] == pytest.approx(expected)
+
+    def test__compute_output_gap(self, test_economy):
+        test_economy.ts.dicts["ppi"] = [[1.0], [1.1]]
+        test_economy.ts.dicts["total_output"] = [[100.0], [132.0]]
+        test_economy.ts.dicts["potential_output"] = [[100.0]]
+
+        test_economy.compute_output_gap()
+
+        expected_real_output = 132.0 / 1.1
+        expected_potential_output = 0.4 * expected_real_output + 0.6 * 100.0
+        expected_output_gap = np.log(expected_real_output) - np.log(expected_potential_output)
+
+        assert test_economy.ts.current("real_gross_output")[0] == pytest.approx(expected_real_output)
+        assert test_economy.ts.current("potential_output")[0] == pytest.approx(expected_potential_output)
+        assert test_economy.ts.current("output_gap")[0] == pytest.approx(expected_output_gap)

--- a/tests/test_macromodel/unit/test_country/test_country.py
+++ b/tests/test_macromodel/unit/test_country/test_country.py
@@ -39,6 +39,7 @@ class TestCountry:
             industries=datawrapper.industries,
             initial_year=datawrapper.configuration.year,
             t_max=12,
+            time_unit=datawrapper.time_unit,
             running_multiple_countries=False,
             emission_factors_usd=emission_factors,
         )


### PR DESCRIPTION
**Issue:**
PolednaPolicyRate produced policy rates at the wrong frequency (annual) despite the model can be run at a different (quarterly) frequency. This may be transmitted to other variables through the monetary policy channel, affecting the macroeconomy and agents' balance sheets.
Moreover, it uses quarter on quarter PPI inflation, which is too noisy for a monetary policy rule and tend to overstimate inflation, and growth instead of output gap. 

**Summary**
This PR adds a new SmoothTaylorRule option for central bank policy and makes rate setup aware of the model time_unit.

**Main changes**
pass time_unit through data setup and simulation setup
convert bank and policy rates from annual values to per-period values
add calibration and runtime support for SmoothTaylorRule
add cpi_yoy_inflation and output_gap to the economy
use those new measures in central bank decisions
update tests and config options

**Notes**
The work is split into 4 commits:

propagate time_unit
convert bank rates to per-period units
add SmoothTaylorRule
add economy metrics used by the policy rule

**Testing**
Unit tests were updated for the new rate handling and policy logic.





