### PR TITLE
Add markup-based bank interest-rate pricing

### DIFF
--- a/macro_data/processing/synthetic_banks/default_synthetic_banks.py
+++ b/macro_data/processing/synthetic_banks/default_synthetic_banks.py
@@ -98,6 +98,10 @@ class DefaultSyntheticBanks(SyntheticBanks):
         hh_mortgage_passthrough: float,
         hh_mortgage_ect: float,
         hh_mortgage_rate: float,
+        firm_short_spread: float,
+        firm_long_spread: float,
+        household_consumption_spread: float,
+        mortgage_spread: float,
         proxy_country: Optional[Country] = None,
     ):
         """Initialize the banking system data container.
@@ -117,6 +121,10 @@ class DefaultSyntheticBanks(SyntheticBanks):
             hh_mortgage_passthrough (float): Estimated mortgage rate parameter
             hh_mortgage_ect (float): Estimated mortgage ECT parameter
             hh_mortgage_rate (float): Initial mortgage rate
+            firm_short_spread (float): Mean pre-start short-term firm loan spread
+            firm_long_spread (float): Mean pre-start long-term firm loan spread
+            household_consumption_spread (float): Mean pre-start household consumption spread
+            mortgage_spread (float): Mean pre-start mortgage spread
             proxy_country (Optional[Country]): Country to use as proxy when missing data
         """
         super().__init__(
@@ -134,6 +142,10 @@ class DefaultSyntheticBanks(SyntheticBanks):
             hh_mortgage_passthrough=hh_mortgage_passthrough,
             hh_mortgage_ect=hh_mortgage_ect,
             hh_mortgage_rate=hh_mortgage_rate,
+            firm_short_spread=firm_short_spread,
+            firm_long_spread=firm_long_spread,
+            household_consumption_spread=household_consumption_spread,
+            mortgage_spread=mortgage_spread,
         )
 
     @classmethod
@@ -220,7 +232,11 @@ class DefaultSyntheticBanks(SyntheticBanks):
             hh_mortgage_ect,
             hh_mortgage_passthrough,
             hh_mortgage_rate,
-        ) = cls.initialise_rates(country_name, inflation_data, proxy_eu_country, quarter, readers, year)
+            firm_short_spread,
+            firm_long_spread,
+            household_consumption_spread,
+            mortgage_spread,
+        ) = cls.initialise_rates(country_name, inflation_data, proxy_eu_country, quarter, readers, year, time_unit)
 
         initial_central_bank_policy_rate = (
             readers.policy_rates.get_policy_rates(country_name).loc[f"{year}-Q{quarter}", "Policy Rate"].values[0]
@@ -243,6 +259,10 @@ class DefaultSyntheticBanks(SyntheticBanks):
             hh_mortgage_passthrough=hh_mortgage_passthrough,
             hh_mortgage_ect=hh_mortgage_ect,
             hh_mortgage_rate=hh_mortgage_rate,
+            firm_short_spread=firm_short_spread,
+            firm_long_spread=firm_long_spread,
+            household_consumption_spread=household_consumption_spread,
+            mortgage_spread=mortgage_spread,
             quarter=quarter,
             proxy_country=proxy_eu_country,
         )
@@ -331,7 +351,11 @@ class DefaultSyntheticBanks(SyntheticBanks):
             hh_mortgage_ect,
             hh_mortgage_passthrough,
             hh_mortgage_rate,
-        ) = cls.initialise_rates(country_name, inflation_data, proxy_eu_country, quarter, readers, year)
+            firm_short_spread,
+            firm_long_spread,
+            household_consumption_spread,
+            mortgage_spread,
+        ) = cls.initialise_rates(country_name, inflation_data, proxy_eu_country, quarter, readers, year, time_unit)
 
         initial_central_bank_policy_rate = (
             readers.policy_rates.get_policy_rates(country_name).loc[f"{year}-Q{quarter}", "Policy Rate"].values[0]
@@ -354,11 +378,83 @@ class DefaultSyntheticBanks(SyntheticBanks):
             hh_mortgage_passthrough=hh_mortgage_passthrough,
             hh_mortgage_ect=hh_mortgage_ect,
             hh_mortgage_rate=hh_mortgage_rate,
+            firm_short_spread=firm_short_spread,
+            firm_long_spread=firm_long_spread,
+            household_consumption_spread=household_consumption_spread,
+            mortgage_spread=mortgage_spread,
             quarter=quarter,
         )
 
     @classmethod
-    def initialise_rates(cls, country_name, inflation_data, proxy_eu_country, quarter, readers, year):
+    @staticmethod
+    def _periods_per_year(time_unit: int) -> int:
+        """Return the number of model periods in one calendar year."""
+        if time_unit <= 0 or 12 % time_unit != 0:
+            raise ValueError("Bank-rate preprocessing requires `time_unit` to be a positive divisor of 12.")
+        return 12 // time_unit
+
+    @classmethod
+    def _convert_annual_rate_to_period(cls, annual_rate: float, time_unit: int) -> float:
+        """Convert an annual quoted rate to the model's per-period convention."""
+        return annual_rate / cls._periods_per_year(time_unit)
+
+    @classmethod
+    def _convert_annual_rate_series_to_period(
+        cls, annual_rates: Optional[pd.Series], time_unit: int
+    ) -> Optional[pd.Series]:
+        """Convert a quoted annual rate series to per-period units."""
+        if annual_rates is None:
+            return None
+        return annual_rates.astype(float) / cls._periods_per_year(time_unit)
+
+    @classmethod
+    def _convert_annual_rate_frame_to_period(
+        cls,
+        annual_rates: pd.DataFrame,
+        time_unit: int,
+        column: str,
+    ) -> pd.DataFrame:
+        """Convert a quoted annual-rate column in a DataFrame to per-period units."""
+        period_rates = annual_rates.copy()
+        period_rates[column] = period_rates[column].astype(float) / cls._periods_per_year(time_unit)
+        return period_rates
+
+    @staticmethod
+    def _initial_policy_rate_quarter_key(year: int, quarter: int) -> str:
+        """Return the pre-start quarter key used for initial policy-rate anchoring."""
+        start_period = pd.Period(year=year, quarter=quarter, freq="Q")
+        initial_period = start_period - 1
+        return f"{initial_period.year}-Q{initial_period.quarter}"
+
+    @staticmethod
+    def _pre_start_mask(index: pd.Index, year: int, quarter: int) -> pd.Series:
+        """Return the mask for quarterly observations strictly before the start quarter."""
+        return index < pd.Timestamp(f"{year}Q{quarter}")
+
+    @classmethod
+    def _mean_pre_start_spread(
+        cls,
+        product_rates: Optional[pd.Series],
+        policy_rates: pd.DataFrame,
+        year: int,
+        quarter: int,
+    ) -> float:
+        """Compute the mean quarterly pre-start spread between a product rate and policy."""
+        if product_rates is None:
+            return 0.0
+
+        df = pd.DataFrame({"product_rate": product_rates}).sort_index()
+        df = pd.merge_asof(df, policy_rates[["Policy Rate"]].sort_index(), left_index=True, right_index=True)
+        df["Policy Rate"] = df["Policy Rate"].ffill()
+        df = df.loc[cls._pre_start_mask(df.index, year, quarter)].dropna(subset=["product_rate", "Policy Rate"])
+
+        if df.empty:
+            return 0.0
+
+        return float((df["product_rate"] - df["Policy Rate"]).mean())
+
+    @classmethod
+    def initialise_rates(cls, country_name, inflation_data, proxy_eu_country, quarter, readers, year, time_unit):
         """Preprocess and estimate initial interest rate parameters.
 
         This method:
@@ -381,7 +477,7 @@ class DefaultSyntheticBanks(SyntheticBanks):
             year (int): Reference year
 
         Returns:
-            tuple: Nine estimated parameters:
+            tuple: Thirteen estimated parameters:
                 - firm_ect: Estimated error correction for firm rates
                 - firm_passthrough: Estimated adjustment for firm rates
                 - firm_rate: Initial firm rate
@@ -391,6 +487,10 @@ class DefaultSyntheticBanks(SyntheticBanks):
                 - hh_mortgage_ect: Estimated mortgage ECT
                 - hh_mortgage_passthrough: Estimated mortgage adjustment
                 - hh_mortgage_rate: Initial mortgage rate
+                - firm_short_spread: Mean pre-start short-term firm spread
+                - firm_long_spread: Mean pre-start long-term firm spread
+                - household_consumption_spread: Mean pre-start household consumption spread
+                - mortgage_spread: Mean pre-start mortgage spread
         """
         if country_name.is_eu_country:
             data_country = country_name
@@ -398,10 +498,27 @@ class DefaultSyntheticBanks(SyntheticBanks):
             if proxy_eu_country is None:
                 raise ValueError("Proxy EU country is required for non-EU countries.")
             data_country = proxy_eu_country
-        firm_rate = readers.ecb_reader.get_firm_rates(data_country)
-        household_consumption_rate = readers.ecb_reader.get_household_consumption_rates(data_country)
-        household_mortgage_rates = readers.ecb_reader.get_household_mortgage_rates(data_country)
-        policy_rates = readers.policy_rates.get_policy_rates(data_country)
+        firm_rate = cls._convert_annual_rate_series_to_period(
+            readers.ecb_reader.get_firm_rates(data_country), time_unit
+        )
+        household_consumption_rate = cls._convert_annual_rate_series_to_period(
+            readers.ecb_reader.get_household_consumption_rates(data_country),
+            time_unit,
+        )
+        household_mortgage_rates = cls._convert_annual_rate_series_to_period(
+            readers.ecb_reader.get_household_mortgage_rates(data_country),
+            time_unit,
+        )
+        policy_rates = cls._convert_annual_rate_frame_to_period(
+            readers.policy_rates.get_policy_rates(data_country),
+            time_unit,
+            "Policy Rate",
+        )
+        firm_spread = cls._mean_pre_start_spread(firm_rate, policy_rates, year, quarter)
+        household_consumption_spread = cls._mean_pre_start_spread(
+            household_consumption_rate, policy_rates, year, quarter
+        )
+        mortgage_spread = cls._mean_pre_start_spread(household_mortgage_rates, policy_rates, year, quarter)
         npl_rates = readers.world_bank.get_npl_ratios(data_country)
         if any(
             [
@@ -447,6 +564,10 @@ class DefaultSyntheticBanks(SyntheticBanks):
             household_mortgages_ect,
             hh_mortgage_passthrough,
             household_mortgages_rate,
+            firm_spread,
+            firm_spread,
+            household_consumption_spread,
+            mortgage_spread,
         )
 
     def set_bank_equity(self, bank_equity: float) -> None:

--- a/macro_data/processing/synthetic_banks/synthetic_banks.py
+++ b/macro_data/processing/synthetic_banks/synthetic_banks.py
@@ -87,6 +87,10 @@ class SyntheticBanks(ABC):
         hh_mortgage_passthrough (float): Estimated mortgage rate parameter
         hh_mortgage_ect (float): Estimated mortgage ECT parameter
         hh_mortgage_rate (float): Initial mortgage rate
+        firm_short_spread (float): Mean pre-start short-term firm loan spread over policy
+        firm_long_spread (float): Mean pre-start long-term firm loan spread over policy
+        household_consumption_spread (float): Mean pre-start household consumption loan spread
+        mortgage_spread (float): Mean pre-start mortgage spread over policy
     """
 
     @abstractmethod
@@ -106,6 +110,10 @@ class SyntheticBanks(ABC):
         hh_mortgage_passthrough: float,
         hh_mortgage_ect: float,
         hh_mortgage_rate: float,
+        firm_short_spread: float,
+        firm_long_spread: float,
+        household_consumption_spread: float,
+        mortgage_spread: float,
     ) -> None:
         """Initialize a synthetic banking system.
 
@@ -124,6 +132,10 @@ class SyntheticBanks(ABC):
             hh_mortgage_passthrough (float): Rate adjustment for mortgages
             hh_mortgage_ect (float): Error correction for mortgage rates
             hh_mortgage_rate (float): Base mortgage rate
+            firm_short_spread (float): Mean pre-start short-term firm loan spread
+            firm_long_spread (float): Mean pre-start long-term firm loan spread
+            household_consumption_spread (float): Mean pre-start household consumption spread
+            mortgage_spread (float): Mean pre-start mortgage spread
         """
         # Parameters
         self.country_name = country_name
@@ -146,6 +158,11 @@ class SyntheticBanks(ABC):
         self.hh_mortgage_passthrough = hh_mortgage_passthrough
         self.hh_mortgage_ect = hh_mortgage_ect
         self.hh_mortgage_rate = hh_mortgage_rate
+
+        self.firm_short_spread = firm_short_spread
+        self.firm_long_spread = firm_long_spread
+        self.household_consumption_spread = household_consumption_spread
+        self.mortgage_spread = mortgage_spread
 
     def initialise_deposits_and_loans(
         self, synthetic_population: SyntheticPopulation, firm_deposits: np.ndarray, firm_debt: np.ndarray
@@ -293,20 +310,8 @@ class SyntheticBanks(ABC):
             mortgage_markup (float): Markup for mortgages
             household_overdraft_markup (float): Markup for household overdrafts
         """
-        bank_markup_interest_rate_short_term_firm_loans = risk_premium
-        bank_markup_interest_rate_long_term_firm_loans = risk_premium
-        bank_markup_interest_rate_household_payday_loans = risk_premium
-        bank_markup_interest_rate_overdraft_firm = risk_premium
-
         self.set_initial_interest_rates(
             central_bank_policy_rate=policy_rate,
-            bank_markup_interest_rate_short_term_firm_loans=bank_markup_interest_rate_short_term_firm_loans,
-            bank_markup_interest_rate_long_term_firm_loans=bank_markup_interest_rate_long_term_firm_loans,
-            bank_markup_interest_rate_household_payday_loans=bank_markup_interest_rate_household_payday_loans,
-            bank_markup_interest_rate_household_consumption_loans=consumption_loans_markup,
-            bank_markup_interest_rate_mortgages=mortgage_markup,
-            bank_markup_interest_rate_overdraft_firm=bank_markup_interest_rate_overdraft_firm,
-            bank_markup_interest_rate_overdraft_household=household_overdraft_markup,
         )
 
         self.set_interest_received_from_loans()
@@ -325,13 +330,6 @@ class SyntheticBanks(ABC):
     def set_initial_interest_rates(
         self,
         central_bank_policy_rate: float,
-        bank_markup_interest_rate_short_term_firm_loans: float,
-        bank_markup_interest_rate_long_term_firm_loans: float,
-        bank_markup_interest_rate_household_payday_loans: float,
-        bank_markup_interest_rate_household_consumption_loans: float,
-        bank_markup_interest_rate_mortgages: float,
-        bank_markup_interest_rate_overdraft_firm: float,
-        bank_markup_interest_rate_overdraft_household: float,
     ) -> None:
         """Set initial interest rates for all bank products.
 
@@ -343,13 +341,6 @@ class SyntheticBanks(ABC):
 
         Args:
             central_bank_policy_rate (float): Base rate from central bank
-            bank_markup_interest_rate_short_term_firm_loans (float): Markup for short-term firm loans
-            bank_markup_interest_rate_long_term_firm_loans (float): Markup for long-term firm loans
-            bank_markup_interest_rate_household_payday_loans (float): Markup for payday loans
-            bank_markup_interest_rate_household_consumption_loans (float): Markup for consumer loans
-            bank_markup_interest_rate_mortgages (float): Markup for mortgages
-            bank_markup_interest_rate_overdraft_firm (float): Markup for firm overdrafts
-            bank_markup_interest_rate_overdraft_household (float): Markup for household overdrafts
         """
         # Short-term interest rates for firm loans
         self.bank_data["Short-Term Interest Rates on Firm Loans"] = self.firm_rate

--- a/macromodel/agents/banks/banks.py
+++ b/macromodel/agents/banks/banks.py
@@ -134,6 +134,20 @@ class Banks(Agent):
         parameters = configuration.parameters
         functions = functions_from_model(model=configuration.functions, loc="macromodel.agents.banks")
 
+        def get_spread(
+            attribute_names: list[str],
+            column_names: list[str],
+        ) -> float | np.ndarray:
+            for attribute_name in attribute_names:
+                if hasattr(synthetic_banks, attribute_name):
+                    spread = getattr(synthetic_banks, attribute_name)
+                    if spread is not None:
+                        return spread
+            for column_name in column_names:
+                if column_name in synthetic_banks.bank_data.columns:
+                    return synthetic_banks.bank_data[column_name].values
+            return 0.0
+
         data = synthetic_banks.bank_data.drop(columns=["Corresponding Firms ID", "Corresponding Households ID"])
         ts = create_banks_timeseries(
             bank_data=data,
@@ -150,6 +164,22 @@ class Banks(Agent):
             "Household Consumption ECT": synthetic_banks.hh_consumption_ect,
             "Household Mortgage Pass Through": synthetic_banks.hh_mortgage_passthrough,
             "Household Mortgage ECT": synthetic_banks.hh_mortgage_ect,
+            "Firm Short Spread": get_spread(
+                attribute_names=["firm_short_spread", "short_term_firm_spread", "firm_spread"],
+                column_names=["Firm Short Spread", "Short-Term Firm Spread", "Firm Spread"],
+            ),
+            "Firm Long Spread": get_spread(
+                attribute_names=["firm_long_spread", "long_term_firm_spread", "firm_spread"],
+                column_names=["Firm Long Spread", "Long-Term Firm Spread", "Firm Spread"],
+            ),
+            "Household Consumption Spread": get_spread(
+                attribute_names=["hh_consumption_spread", "household_consumption_spread"],
+                column_names=["Household Consumption Spread"],
+            ),
+            "Mortgage Spread": get_spread(
+                attribute_names=["mortgage_spread", "hh_mortgage_spread", "household_mortgage_spread"],
+                column_names=["Mortgage Spread", "Household Mortgage Spread"],
+            ),
         }
 
         return cls(
@@ -225,6 +255,7 @@ class Banks(Agent):
                 prev_interest_rates_on_short_term_firm_loans=self.ts.current("interest_rates_on_short_term_firm_loans"),
                 firm_pt=self.states["Firm Pass Through"],
                 firm_ect=self.states["Firm ECT"],
+                firm_short_spread=self.states["Firm Short Spread"],
             )
         )
         self.ts.average_interest_rates_on_short_term_firm_loans.append(
@@ -236,6 +267,7 @@ class Banks(Agent):
                 prev_interest_rates_on_long_term_firm_loans=self.ts.current("interest_rates_on_long_term_firm_loans"),
                 firm_pt=self.states["Firm Pass Through"],
                 firm_ect=self.states["Firm ECT"],
+                firm_long_spread=self.states["Firm Long Spread"],
             )
         )
         self.ts.average_interest_rates_on_long_term_firm_loans.append(
@@ -249,6 +281,7 @@ class Banks(Agent):
                 ),
                 hh_cons_pt=self.states["Household Consumption Pass Through"],
                 hh_cons_ect=self.states["Household Consumption ECT"],
+                hh_consumption_spread=self.states["Household Consumption Spread"],
             )
         )
         self.ts.average_interest_rates_on_household_consumption_loans.append(
@@ -260,6 +293,7 @@ class Banks(Agent):
                 prev_interest_rate_on_mortgages=self.ts.current("interest_rates_on_mortgages"),
                 hh_mortgage_pt=self.states["Household Mortgage Pass Through"],
                 hh_mortgage_ect=self.states["Household Mortgage ECT"],
+                mortgage_spread=self.states["Mortgage Spread"],
             )
         )
         self.ts.average_interest_rates_on_mortgages.append([self.ts.current("interest_rates_on_mortgages").mean()])

--- a/macromodel/agents/banks/func/interest_rates.py
+++ b/macromodel/agents/banks/func/interest_rates.py
@@ -43,6 +43,7 @@ class InterestRatesSetter(ABC):
         prev_interest_rates_on_short_term_firm_loans: np.ndarray,
         firm_pt: float,
         firm_ect: float,
+        firm_short_spread: float | np.ndarray | None = None,
     ) -> np.ndarray:
         """Calculate short-term firm loan rates.
 
@@ -65,6 +66,7 @@ class InterestRatesSetter(ABC):
         prev_interest_rates_on_long_term_firm_loans: np.ndarray,
         firm_pt: float,
         firm_ect: float,
+        firm_long_spread: float | np.ndarray | None = None,
     ) -> np.ndarray:
         """Calculate long-term firm loan rates.
 
@@ -87,6 +89,7 @@ class InterestRatesSetter(ABC):
         prev_interest_rate_on_hh_consumption_loans: np.ndarray,
         hh_cons_pt: float,
         hh_cons_ect: float,
+        hh_consumption_spread: float | np.ndarray | None = None,
     ) -> np.ndarray:
         """Calculate household consumption loan rates.
 
@@ -109,6 +112,7 @@ class InterestRatesSetter(ABC):
         prev_interest_rate_on_mortgages: np.ndarray,
         hh_mortgage_pt: float,
         hh_mortgage_ect: float,
+        mortgage_spread: float | np.ndarray | None = None,
     ) -> np.ndarray:
         """Calculate mortgage rates.
 
@@ -235,6 +239,7 @@ class DefaultInterestRatesSetter(InterestRatesSetter):
         prev_interest_rates_on_short_term_firm_loans: np.ndarray,
         firm_pt: float,
         firm_ect: float,
+        firm_short_spread: float | np.ndarray | None = None,
     ) -> np.ndarray:
         """Calculate short-term firm loan rates.
 
@@ -264,6 +269,7 @@ class DefaultInterestRatesSetter(InterestRatesSetter):
         prev_interest_rates_on_long_term_firm_loans: np.ndarray,
         firm_pt: float,
         firm_ect: float,
+        firm_long_spread: float | np.ndarray | None = None,
     ) -> np.ndarray:
         """Calculate long-term firm loan rates.
 
@@ -293,6 +299,7 @@ class DefaultInterestRatesSetter(InterestRatesSetter):
         prev_interest_rate_on_hh_consumption_loans: np.ndarray,
         hh_cons_pt: float,
         hh_cons_ect: float,
+        hh_consumption_spread: float | np.ndarray | None = None,
     ) -> np.ndarray:
         """Calculate household consumption loan rates.
 
@@ -322,6 +329,7 @@ class DefaultInterestRatesSetter(InterestRatesSetter):
         prev_interest_rate_on_mortgages: np.ndarray,
         hh_mortgage_pt: float,
         hh_mortgage_ect: float,
+        mortgage_spread: float | np.ndarray | None = None,
     ) -> np.ndarray:
         """Calculate mortgage rates.
 
@@ -448,3 +456,136 @@ class DefaultInterestRatesSetter(InterestRatesSetter):
         return prev_overdraft_rate_on_hh_deposits + hh_cons_ect * (
             prev_overdraft_rate_on_hh_deposits - hh_cons_pt * central_bank_policy_rate
         )
+
+
+class MarkUpInterestRatesSetter(InterestRatesSetter):
+    """Interest rate setter using product-specific policy-rate markups."""
+
+    def __init__(
+        self,
+        firm_short_spread: float | None = None,
+        firm_long_spread: float | None = None,
+        firm_spread: float | None = None,
+        hh_consumption_spread: float | None = None,
+        household_consumption_spread: float | None = None,
+        mortgage_spread: float | None = None,
+        hh_mortgage_spread: float | None = None,
+        household_mortgage_spread: float | None = None,
+    ) -> None:
+        self.firm_short_spread = firm_short_spread if firm_short_spread is not None else firm_spread
+        self.firm_long_spread = firm_long_spread if firm_long_spread is not None else firm_spread
+        self.hh_consumption_spread = (
+            hh_consumption_spread
+            if hh_consumption_spread is not None
+            else household_consumption_spread
+        )
+        self.mortgage_spread = mortgage_spread
+        if self.mortgage_spread is None:
+            self.mortgage_spread = hh_mortgage_spread
+        if self.mortgage_spread is None:
+            self.mortgage_spread = household_mortgage_spread
+
+    @staticmethod
+    def _policy_plus_spread(
+        central_bank_policy_rate: float,
+        prev_interest_rates: np.ndarray,
+        spread: float | np.ndarray | None,
+    ) -> np.ndarray:
+        spread_array = np.asarray(0.0 if spread is None else spread, dtype=float)
+        if spread_array.shape == ():
+            spread_array = np.full(prev_interest_rates.shape, float(spread_array))
+        else:
+            spread_array = np.broadcast_to(spread_array, prev_interest_rates.shape)
+        return np.maximum(central_bank_policy_rate + spread_array, 0.0)
+
+    def get_interest_rates_on_short_term_firm_loans(
+        self,
+        central_bank_policy_rate: float,
+        prev_interest_rates_on_short_term_firm_loans: np.ndarray,
+        firm_pt: float,
+        firm_ect: float,
+        firm_short_spread: float | np.ndarray | None = None,
+    ) -> np.ndarray:
+        return self._policy_plus_spread(
+            central_bank_policy_rate=central_bank_policy_rate,
+            prev_interest_rates=prev_interest_rates_on_short_term_firm_loans,
+            spread=self.firm_short_spread if self.firm_short_spread is not None else firm_short_spread,
+        )
+
+    def get_interest_rates_on_long_term_firm_loans(
+        self,
+        central_bank_policy_rate: float,
+        prev_interest_rates_on_long_term_firm_loans: np.ndarray,
+        firm_pt: float,
+        firm_ect: float,
+        firm_long_spread: float | np.ndarray | None = None,
+    ) -> np.ndarray:
+        return self._policy_plus_spread(
+            central_bank_policy_rate=central_bank_policy_rate,
+            prev_interest_rates=prev_interest_rates_on_long_term_firm_loans,
+            spread=self.firm_long_spread if self.firm_long_spread is not None else firm_long_spread,
+        )
+
+    def get_interest_rates_on_household_consumption_loans(
+        self,
+        central_bank_policy_rate: float,
+        prev_interest_rate_on_hh_consumption_loans: np.ndarray,
+        hh_cons_pt: float,
+        hh_cons_ect: float,
+        hh_consumption_spread: float | np.ndarray | None = None,
+    ) -> np.ndarray:
+        return self._policy_plus_spread(
+            central_bank_policy_rate=central_bank_policy_rate,
+            prev_interest_rates=prev_interest_rate_on_hh_consumption_loans,
+            spread=self.hh_consumption_spread if self.hh_consumption_spread is not None else hh_consumption_spread,
+        )
+
+    def get_interest_rate_on_mortgages(
+        self,
+        central_bank_policy_rate: float,
+        prev_interest_rate_on_mortgages: np.ndarray,
+        hh_mortgage_pt: float,
+        hh_mortgage_ect: float,
+        mortgage_spread: float | np.ndarray | None = None,
+    ) -> np.ndarray:
+        return self._policy_plus_spread(
+            central_bank_policy_rate=central_bank_policy_rate,
+            prev_interest_rates=prev_interest_rate_on_mortgages,
+            spread=self.mortgage_spread if self.mortgage_spread is not None else mortgage_spread,
+        )
+
+    def compute_interest_rate_on_firm_deposits(
+        self,
+        central_bank_policy_rate: float,
+        prev_interest_rate_on_firm_deposits: np.ndarray,
+        firm_pt: float,
+        firm_ect: float,
+    ) -> np.ndarray:
+        return np.full(prev_interest_rate_on_firm_deposits.shape, central_bank_policy_rate)
+
+    def compute_overdraft_rate_on_firm_deposits(
+        self,
+        central_bank_policy_rate: float,
+        prev_overdraft_rate_on_firm_deposits: np.ndarray,
+        firm_pt: float,
+        firm_ect: float,
+    ) -> np.ndarray:
+        return np.full(prev_overdraft_rate_on_firm_deposits.shape, central_bank_policy_rate)
+
+    def compute_interest_rate_on_household_deposits(
+        self,
+        central_bank_policy_rate: float,
+        prev_interest_rate_on_hh_deposits: np.ndarray,
+        hh_cons_pt: float,
+        hh_cons_ect: float,
+    ) -> np.ndarray:
+        return np.full(prev_interest_rate_on_hh_deposits.shape, central_bank_policy_rate)
+
+    def compute_overdraft_rate_on_household_deposits(
+        self,
+        central_bank_policy_rate: float,
+        prev_overdraft_rate_on_hh_deposits: np.ndarray,
+        hh_cons_pt: float,
+        hh_cons_ect: float,
+    ) -> np.ndarray:
+        return np.full(prev_overdraft_rate_on_hh_deposits.shape, central_bank_policy_rate)

--- a/macromodel/agents/banks/func/interest_rates.py
+++ b/macromodel/agents/banks/func/interest_rates.py
@@ -475,9 +475,7 @@ class MarkUpInterestRatesSetter(InterestRatesSetter):
         self.firm_short_spread = firm_short_spread if firm_short_spread is not None else firm_spread
         self.firm_long_spread = firm_long_spread if firm_long_spread is not None else firm_spread
         self.hh_consumption_spread = (
-            hh_consumption_spread
-            if hh_consumption_spread is not None
-            else household_consumption_spread
+            hh_consumption_spread if hh_consumption_spread is not None else household_consumption_spread
         )
         self.mortgage_spread = mortgage_spread
         if self.mortgage_spread is None:

--- a/macromodel/configurations/bank_configuration.py
+++ b/macromodel/configurations/bank_configuration.py
@@ -118,7 +118,7 @@ class InterestRateFunction(BaseModel):
     """
 
     path_name: str = "interest_rates"
-    name: Literal["DefaultInterestRatesSetter"] = "DefaultInterestRatesSetter"
+    name: Literal["DefaultInterestRatesSetter", "MarkUpInterestRatesSetter"] = "DefaultInterestRatesSetter"
     parameters: dict[str, Any] = {}
 
 

--- a/tests/test_macro_data/unit/default_unit_test.yaml
+++ b/tests/test_macro_data/unit/default_unit_test.yaml
@@ -10,7 +10,7 @@ FRA:
       interest_rates:
         name:
           desc: The function used for setting interest rates.
-          options: DefaultInterestRatesSetter
+          options: DefaultInterestRatesSetter,MarkUpInterestRatesSetter
           type: str
           value: DefaultInterestRatesSetter
         parameters:

--- a/tests/test_macro_data/unit/test_processing/test_synthetic_banks/test_synthetic_banks.py
+++ b/tests/test_macro_data/unit/test_processing/test_synthetic_banks/test_synthetic_banks.py
@@ -60,6 +60,48 @@ class TestSyntheticBanks:
         }
 
         assert set(banks.bank_data.columns) == columns
+        annual_policy_rate = (
+            readers.policy_rates.get_policy_rates(Country("FRA")).loc["2013-Q4", "Policy Rate"].values[0]
+        )
+        assert banks.bank_data["Interest Rates on Firm Deposits"].values[0] == annual_policy_rate / 4.0
+        assert banks.bank_data["Interest Rates on Household Deposits"].values[0] == annual_policy_rate / 4.0
+        firm_rates = DefaultSyntheticBanks._convert_annual_rate_series_to_period(
+            readers.ecb_reader.get_firm_rates(Country("FRA")),
+            time_unit=3,
+        )
+        household_consumption_rates = DefaultSyntheticBanks._convert_annual_rate_series_to_period(
+            readers.ecb_reader.get_household_consumption_rates(Country("FRA")),
+            time_unit=3,
+        )
+        mortgage_rates = DefaultSyntheticBanks._convert_annual_rate_series_to_period(
+            readers.ecb_reader.get_household_mortgage_rates(Country("FRA")),
+            time_unit=3,
+        )
+        policy_rates = DefaultSyntheticBanks._convert_annual_rate_frame_to_period(
+            readers.policy_rates.get_policy_rates(Country("FRA")),
+            time_unit=3,
+            column="Policy Rate",
+        )
+
+        assert banks.firm_short_spread == DefaultSyntheticBanks._mean_pre_start_spread(
+            firm_rates,
+            policy_rates,
+            year=2014,
+            quarter=1,
+        )
+        assert banks.firm_long_spread == banks.firm_short_spread
+        assert banks.household_consumption_spread == DefaultSyntheticBanks._mean_pre_start_spread(
+            household_consumption_rates,
+            policy_rates,
+            year=2014,
+            quarter=1,
+        )
+        assert banks.mortgage_spread == DefaultSyntheticBanks._mean_pre_start_spread(
+            mortgage_rates,
+            policy_rates,
+            year=2014,
+            quarter=1,
+        )
         # Check if we have all the necessary fields
         # for bank_field in [
         #     "Equity",

--- a/tests/test_macromodel/unit/default_unit_test.yaml
+++ b/tests/test_macromodel/unit/default_unit_test.yaml
@@ -16,7 +16,7 @@ FRA:
       interest_rates:
         name:
           desc: The function used for setting interest rates.
-          options: DefaultInterestRatesSetter
+          options: DefaultInterestRatesSetter,MarkUpInterestRatesSetter
           type: str
           value: DefaultInterestRatesSetter
       profit_estimator:

--- a/tests/test_macromodel/unit/test_agents/test_banks/func/test_interest_rates.py
+++ b/tests/test_macromodel/unit/test_agents/test_banks/func/test_interest_rates.py
@@ -161,7 +161,9 @@ class TestBanksMarkUpInterestRates:
         np.testing.assert_allclose(test_banks.ts.current("interest_rates_on_long_term_firm_loans"), 0.035)
         np.testing.assert_allclose(test_banks.ts.current("interest_rates_on_household_consumption_loans"), 0.04)
         np.testing.assert_allclose(test_banks.ts.current("interest_rates_on_mortgages"), 0.025)
-        np.testing.assert_allclose(test_banks.ts.current("interest_rate_on_firm_deposits"), np.full(deposit_template.shape, 0.02))
+        np.testing.assert_allclose(
+            test_banks.ts.current("interest_rate_on_firm_deposits"), np.full(deposit_template.shape, 0.02)
+        )
         np.testing.assert_allclose(
             test_banks.ts.current("interest_rate_on_household_deposits"),
             np.full(deposit_template.shape, 0.02),

--- a/tests/test_macromodel/unit/test_agents/test_banks/func/test_interest_rates.py
+++ b/tests/test_macromodel/unit/test_agents/test_banks/func/test_interest_rates.py
@@ -1,0 +1,201 @@
+import numpy as np
+from pydantic import BaseModel, Field
+
+from macromodel.agents.banks.func.interest_rates import (
+    DefaultInterestRatesSetter,
+    MarkUpInterestRatesSetter,
+)
+from macromodel.util.function_mapping import functions_from_model
+
+
+class _InterestRateFunctionConfig(BaseModel):
+    path_name: str = "interest_rates"
+    name: str = "MarkUpInterestRatesSetter"
+    parameters: dict = Field(
+        default_factory=lambda: {
+            "firm_short_spread": 0.03,
+            "firm_long_spread": 0.04,
+            "hh_consumption_spread": 0.05,
+            "mortgage_spread": 0.02,
+        }
+    )
+
+
+class _BankFunctionConfig(BaseModel):
+    interest_rates: _InterestRateFunctionConfig = _InterestRateFunctionConfig()
+
+
+class TestDefaultInterestRatesSetter:
+    def test_keeps_existing_ect_formula(self):
+        setter = DefaultInterestRatesSetter()
+
+        prev_rates = np.array([0.03, 0.04])
+        result = setter.get_interest_rates_on_short_term_firm_loans(
+            central_bank_policy_rate=0.02,
+            prev_interest_rates_on_short_term_firm_loans=prev_rates,
+            firm_pt=0.8,
+            firm_ect=0.5,
+            firm_short_spread=np.array([0.10, 0.10]),
+        )
+
+        np.testing.assert_allclose(result, prev_rates + 0.5 * (prev_rates - 0.8 * 0.02))
+
+
+class TestMarkUpInterestRatesSetter:
+    def test_selects_from_model_with_constructor_overrides(self):
+        functions = functions_from_model(
+            model=_BankFunctionConfig(),
+            loc="macromodel.agents.banks",
+        )
+
+        setter = functions["interest_rates"]
+        assert isinstance(setter, MarkUpInterestRatesSetter)
+        assert setter.firm_short_spread == 0.03
+        assert setter.firm_long_spread == 0.04
+        assert setter.hh_consumption_spread == 0.05
+        assert setter.mortgage_spread == 0.02
+
+    def test_constructor_overrides_bank_state_spreads(self):
+        setter = MarkUpInterestRatesSetter(
+            firm_short_spread=0.03,
+            firm_long_spread=0.04,
+            hh_consumption_spread=0.05,
+            mortgage_spread=0.02,
+        )
+
+        np.testing.assert_allclose(
+            setter.get_interest_rates_on_short_term_firm_loans(
+                central_bank_policy_rate=0.01,
+                prev_interest_rates_on_short_term_firm_loans=np.array([0.07, 0.08]),
+                firm_pt=0.0,
+                firm_ect=0.0,
+                firm_short_spread=np.array([0.10, 0.11]),
+            ),
+            np.array([0.04, 0.04]),
+        )
+        np.testing.assert_allclose(
+            setter.get_interest_rates_on_long_term_firm_loans(
+                central_bank_policy_rate=0.01,
+                prev_interest_rates_on_long_term_firm_loans=np.array([0.07, 0.08]),
+                firm_pt=0.0,
+                firm_ect=0.0,
+                firm_long_spread=np.array([0.10, 0.11]),
+            ),
+            np.array([0.05, 0.05]),
+        )
+        np.testing.assert_allclose(
+            setter.get_interest_rates_on_household_consumption_loans(
+                central_bank_policy_rate=0.01,
+                prev_interest_rate_on_hh_consumption_loans=np.array([0.07, 0.08]),
+                hh_cons_pt=0.0,
+                hh_cons_ect=0.0,
+                hh_consumption_spread=np.array([0.10, 0.11]),
+            ),
+            np.array([0.06, 0.06]),
+        )
+        np.testing.assert_allclose(
+            setter.get_interest_rate_on_mortgages(
+                central_bank_policy_rate=0.01,
+                prev_interest_rate_on_mortgages=np.array([0.07, 0.08]),
+                hh_mortgage_pt=0.0,
+                hh_mortgage_ect=0.0,
+                mortgage_spread=np.array([0.10, 0.11]),
+            ),
+            np.array([0.03, 0.03]),
+        )
+
+    def test_falls_back_to_state_spreads_and_applies_floor(self):
+        setter = MarkUpInterestRatesSetter()
+
+        result = setter.get_interest_rates_on_short_term_firm_loans(
+            central_bank_policy_rate=0.01,
+            prev_interest_rates_on_short_term_firm_loans=np.array([0.07, 0.08]),
+            firm_pt=0.0,
+            firm_ect=0.0,
+            firm_short_spread=np.array([-0.05, 0.02]),
+        )
+
+        np.testing.assert_allclose(result, np.array([0.00, 0.03]))
+
+    def test_keeps_deposit_side_at_policy_rate(self):
+        setter = MarkUpInterestRatesSetter()
+
+        np.testing.assert_allclose(
+            setter.compute_interest_rate_on_firm_deposits(
+                central_bank_policy_rate=0.02,
+                prev_interest_rate_on_firm_deposits=np.array([0.01, 0.03]),
+                firm_pt=0.0,
+                firm_ect=0.0,
+            ),
+            np.array([0.02, 0.02]),
+        )
+        np.testing.assert_allclose(
+            setter.compute_overdraft_rate_on_household_deposits(
+                central_bank_policy_rate=0.02,
+                prev_overdraft_rate_on_hh_deposits=np.array([0.05, 0.06]),
+                hh_cons_pt=0.0,
+                hh_cons_ect=0.0,
+            ),
+            np.array([0.02, 0.02]),
+        )
+
+
+class TestBanksMarkUpInterestRates:
+    def test_set_interest_rates_uses_bank_state_spreads(self, test_banks):
+        test_banks.functions["interest_rates"] = MarkUpInterestRatesSetter()
+
+        short_template = test_banks.ts.current("interest_rates_on_short_term_firm_loans")
+        long_template = test_banks.ts.current("interest_rates_on_long_term_firm_loans")
+        cons_template = test_banks.ts.current("interest_rates_on_household_consumption_loans")
+        mortgage_template = test_banks.ts.current("interest_rates_on_mortgages")
+        deposit_template = test_banks.ts.current("interest_rate_on_firm_deposits")
+
+        test_banks.states["Firm Short Spread"] = np.full(short_template.shape, 0.01)
+        test_banks.states["Firm Long Spread"] = np.full(long_template.shape, 0.015)
+        test_banks.states["Household Consumption Spread"] = np.full(cons_template.shape, 0.02)
+        test_banks.states["Mortgage Spread"] = np.full(mortgage_template.shape, 0.005)
+
+        test_banks.set_interest_rates(central_bank_policy_rate=0.02)
+
+        np.testing.assert_allclose(test_banks.ts.current("interest_rates_on_short_term_firm_loans"), 0.03)
+        np.testing.assert_allclose(test_banks.ts.current("interest_rates_on_long_term_firm_loans"), 0.035)
+        np.testing.assert_allclose(test_banks.ts.current("interest_rates_on_household_consumption_loans"), 0.04)
+        np.testing.assert_allclose(test_banks.ts.current("interest_rates_on_mortgages"), 0.025)
+        np.testing.assert_allclose(test_banks.ts.current("interest_rate_on_firm_deposits"), np.full(deposit_template.shape, 0.02))
+        np.testing.assert_allclose(
+            test_banks.ts.current("interest_rate_on_household_deposits"),
+            np.full(deposit_template.shape, 0.02),
+        )
+        np.testing.assert_allclose(
+            test_banks.ts.current("overdraft_rate_on_firm_deposits"),
+            np.full(deposit_template.shape, 0.02),
+        )
+        np.testing.assert_allclose(
+            test_banks.ts.current("overdraft_rate_on_household_deposits"),
+            np.full(deposit_template.shape, 0.02),
+        )
+
+    def test_set_interest_rates_prefers_constructor_overrides(self, test_banks):
+        test_banks.functions["interest_rates"] = MarkUpInterestRatesSetter(
+            firm_short_spread=0.03,
+            firm_long_spread=0.04,
+            hh_consumption_spread=0.05,
+            mortgage_spread=0.02,
+        )
+
+        short_template = test_banks.ts.current("interest_rates_on_short_term_firm_loans")
+        long_template = test_banks.ts.current("interest_rates_on_long_term_firm_loans")
+        cons_template = test_banks.ts.current("interest_rates_on_household_consumption_loans")
+        mortgage_template = test_banks.ts.current("interest_rates_on_mortgages")
+
+        test_banks.states["Firm Short Spread"] = np.full(short_template.shape, 0.50)
+        test_banks.states["Firm Long Spread"] = np.full(long_template.shape, 0.50)
+        test_banks.states["Household Consumption Spread"] = np.full(cons_template.shape, 0.50)
+        test_banks.states["Mortgage Spread"] = np.full(mortgage_template.shape, 0.50)
+
+        test_banks.set_interest_rates(central_bank_policy_rate=0.01)
+
+        np.testing.assert_allclose(test_banks.ts.current("interest_rates_on_short_term_firm_loans"), 0.04)
+        np.testing.assert_allclose(test_banks.ts.current("interest_rates_on_long_term_firm_loans"), 0.05)
+        np.testing.assert_allclose(test_banks.ts.current("interest_rates_on_household_consumption_loans"), 0.06)
+        np.testing.assert_allclose(test_banks.ts.current("interest_rates_on_mortgages"), 0.03)

--- a/tests/test_macromodel/unit/test_agents/test_banks/test_banks.py
+++ b/tests/test_macromodel/unit/test_agents/test_banks/test_banks.py
@@ -10,6 +10,10 @@ class TestBanks:
             "Household Consumption ECT",
             "Household Mortgage Pass Through",
             "Household Mortgage ECT",
+            "Firm Short Spread",
+            "Firm Long Spread",
+            "Household Consumption Spread",
+            "Mortgage Spread",
         }
 
         ts_keys = [


### PR DESCRIPTION
**Dependency**
Blocked by #83
This PR contains commits from #83 and should be reviewed after that merges.

**Issue**
The existing bank-rate setup could produce borrowing rates below the policy rate. It also did not provide a clean way to switch between the current ECT behaviour and a simple policy-plus-spread rule.

**Changes**
add MarkUpInterestRatesSetter while keeping DefaultInterestRatesSetter unchanged
calibrate mean pre-start spreads from quarterly product-rate minus policy-rate data
store those spreads on synthetic banks and pass them into bank state
price loans under the markup rule as max(policy_rate + spread, 0)
keep deposit-side rates at policy in the markup regime
allow selecting MarkUpInterestRatesSetter in bank config
support optional runtime spread overrides via setter parameters
add/update tests for spread calibration and markup pricing
**Notes**
both firm short and firm long spreads currently use the same calibrated firm spread
existing ECT behaviour is unchanged

ECT behaviour
<img width="556" height="413" alt="rates_etc" src="https://github.com/user-attachments/assets/1d79af78-b6e9-4b67-a742-87b37cbbc1d1" />

Mark-up behaviour
<img width="556" height="413" alt="rates_markup" src="https://github.com/user-attachments/assets/b4d97a49-c1b5-4824-afde-978a306339a6" />
