### PR TITLE
ci: run apt-get update before installing libhdf5-dev

### DIFF
--- a/.github/workflows/build_macrocalib.yaml
+++ b/.github/workflows/build_macrocalib.yaml
@@ -26,7 +26,9 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
 
       - name: Install h5py dependencies
-        run: sudo apt-get install libhdf5-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libhdf5-dev
 
       - name: Install calibration dependencies
         run: |

--- a/.github/workflows/build_macrodata.yml
+++ b/.github/workflows/build_macrodata.yml
@@ -29,7 +29,8 @@ jobs:
 
       - name: Install h5py dependencies
         run: |
-          sudo apt-get install libhdf5-dev
+          sudo apt-get update
+          sudo apt-get install -y libhdf5-dev
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/build_macromodel.yml
+++ b/.github/workflows/build_macromodel.yml
@@ -28,7 +28,8 @@ jobs:
 
       - name: Install h5py dependencies
         run: |
-          sudo apt-get install libhdf5-dev    
+          sudo apt-get update
+          sudo apt-get install -y libhdf5-dev
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,7 +34,8 @@ jobs:
 
       - name: Install h5py dependencies
         run: |
-          sudo apt-get install libhdf5-dev
+          sudo apt-get update
+          sudo apt-get install -y libhdf5-dev
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary
- The `Build and test data package` and `Deploy docs to GitHub Pages` workflows started failing on `sudo apt-get install libhdf5-dev` with a 404 on `libcurl4-openssl-dev_8.5.0-2ubuntu10.8_amd64.deb`. Root cause is the GitHub-hosted runner's preinstalled apt index pointing at a `.deb` URL that has since been superseded by a newer point release on the Ubuntu mirror.
- Prepend `sudo apt-get update` before each `apt-get install libhdf5-dev` step so the index is refreshed against the current mirror state, and add `-y` so the install is non-interactive.
- Applied to all four workflow files that install `libhdf5-dev`: `build_macrodata.yml`, `build_macromodel.yml`, `build_macrocalib.yaml`, `docs.yml`.

## Test plan
- [ ] `Build and test data package` workflow passes on this PR
- [ ] `Build and test model package` workflow passes on this PR
- [ ] `Build and test calibration package` workflow passes on this PR
- [ ] `Deploy docs to GitHub Pages` runs cleanly on merge to main