### PR TITLE
fix: stable sigmoid in household property demand (#88)

### DIFF
--- a/macromodel/agents/households/func/property.py
+++ b/macromodel/agents/households/func/property.py
@@ -14,12 +14,12 @@ The implementation handles:
 - Property value adjustments
 """
 
-import warnings
 from abc import ABC, abstractmethod
 from typing import Tuple
 
 import numpy as np
 import pandas as pd
+from scipy.special import expit
 
 
 class HouseholdDemandForProperty(ABC):
@@ -291,14 +291,11 @@ class DefaultHouseholdDemandForProperty(HouseholdDemandForProperty):
             4 * np.maximum(0, max_amount_pay - household_financial_wealth[ind_dec]) / assumed_mortgage_maturity
             - ((1 + expected_hpi_growth) ** 4 - 1) * max_value_affordable
         )
-        # Use logistic function to calculate probability of buying
-        # Normalize cost difference for numerical stability
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            diff = (annual_cost_of_renting - annual_cost_of_purchasing) / 10000
-            diff_exp = np.exp(-self.cost_comparison_temperature * diff)
-            prob_buying = 1.0 / (1.0 + diff_exp)
-            prob_buying = np.clip(prob_buying, 0.0, 1.0)
+        # Logistic probability of buying, normalized by 10000.
+        # scipy.special.expit is a numerically stable sigmoid that saturates
+        # safely at the float64 limits.
+        diff = (annual_cost_of_renting - annual_cost_of_purchasing) / 10000
+        prob_buying = expit(self.cost_comparison_temperature * diff)
         ind_deciding_to_buy_rel = np.random.random(prob_buying.shape) < prob_buying
         ind_deciding_to_rent_rel = ~ind_deciding_to_buy_rel
         ind_deciding_to_buy = np.where(ind_dec)[0][ind_deciding_to_buy_rel]


### PR DESCRIPTION
## Summary
- Closes #88. Replaces the unstable `1 / (1 + exp(-z))` at [macromodel/agents/households/func/property.py:299](macromodel/agents/households/func/property.py#L299) with `scipy.special.expit`, which saturates safely at the float64 limits.
- Drops the `with warnings.catch_warnings(): warnings.simplefilter("ignore")` wrapper around the sigmoid. That suppressor only silences Python warnings — it cannot suppress `FloatingPointError` from `np.seterr(all="raise")`, which is what the reporter was hitting. With a numerically stable sigmoid the suppressor is no longer needed at all.
- Also drops the now-redundant `np.clip(prob_buying, 0.0, 1.0)` — `expit` is mathematically guaranteed to return a value in `[0, 1]`.

## Why this fixes the reported error
The reporter ran the README tutorial with `np.seterr(all="raise")` and got `FloatingPointError: underflow encountered in exp` at line 299. When the rent-vs-buy cost difference is large, `exp(-temperature * diff)` underflows to 0 — mathematically the right answer for the sigmoid (it saturates to 1.0), but raised as a floating-point error under strict mode. `scipy.special.expit` is implemented to handle both saturating tails without overflow or underflow.

The reporter's second concern (unrealistic GDP / household income magnitudes when the underflow is ignored) is a separate issue and is **not** addressed by this PR — that's a tutorial / calibration question on the toy sample data.

## Test plan
- [x] `uv run pytest tests/test_macromodel/` — 179 passed
- [x] `uv run pytest tests/test_macro_data/ tests/test_macrocalib/` — 105 passed
- [x] Reproduction script from the issue now completes without `FloatingPointError`
- [x] `uv run ruff check` and `uv run ruff format --check` clean