### PR TITLE
Fix housing market accounting combined main

### DIFF
--- a/macromodel/agents/households/func/property.py
+++ b/macromodel/agents/households/func/property.py
@@ -258,6 +258,7 @@ class DefaultHouseholdDemandForProperty(HouseholdDemandForProperty):
         """
         # Indices
         ind_in_social_housing = household_residence_tenure_status == -1
+        # Tenure status 3 is the model code for private renters.
         ind_renting = np.array(household_residence_tenure_status == 3)
         ind_renting_not_staying = np.logical_and(
             ind_renting,

--- a/macromodel/agents/households/func/property.py
+++ b/macromodel/agents/households/func/property.py
@@ -258,7 +258,7 @@ class DefaultHouseholdDemandForProperty(HouseholdDemandForProperty):
         """
         # Indices
         ind_in_social_housing = household_residence_tenure_status == -1
-        ind_renting = np.array(household_residence_tenure_status == 0)
+        ind_renting = np.array(household_residence_tenure_status == 3)
         ind_renting_not_staying = np.logical_and(
             ind_renting,
             np.random.random(ind_renting.shape[0]) > self.probability_stay_in_rented_property,

--- a/macromodel/agents/households/households.py
+++ b/macromodel/agents/households/households.py
@@ -811,9 +811,10 @@ class Households(Agent):
         )
 
         # Set what's up for rent
-        prev_up_for_rent = housing_data["Up for Rent"].values
-        now_up_for_rent = np.where(np.isnan(housing_data["Corresponding Inhabitant Household ID"].values))[0]
-        newly_up_for_rent = [ind for ind in now_up_for_rent if ind not in prev_up_for_rent]
+        prev_up_for_rent = np.flatnonzero(housing_data["Up for Rent"].eq(True).values)
+        inhabitant_ids = housing_data["Corresponding Inhabitant Household ID"].values
+        now_up_for_rent = np.where(np.logical_or(np.isnan(inhabitant_ids), inhabitant_ids == -1))[0]
+        newly_up_for_rent = np.setdiff1d(now_up_for_rent, prev_up_for_rent)
         housing_data["Up for Rent"] = False
         housing_data.loc[now_up_for_rent, "Up for Rent"] = True
         housing_data["Newly on the Rental Market"] = False

--- a/macromodel/agents/households/households.py
+++ b/macromodel/agents/households/households.py
@@ -779,8 +779,15 @@ class Households(Agent):
         self.ts.max_price_willing_to_pay.append(max_price_willing_to_pay)
         self.ts.max_rent_willing_to_pay.append(max_rent_willing_to_pay)
 
-        # Set price of properties of households that are hoping to move
-        ind_mhr_temp_sale = housing_data["Corresponding Owner Household ID"].isin(households_hoping_to_move)
+        # Set price of properties of households that are hoping to move.
+        # The property function returns a household-level boolean mask.
+        household_ids_hoping_to_move = np.flatnonzero(households_hoping_to_move)
+        owner_ids = housing_data["Corresponding Owner Household ID"]
+        inhabitant_ids = housing_data["Corresponding Inhabitant Household ID"]
+        owner_wants_to_move = owner_ids.isin(household_ids_hoping_to_move)
+        property_is_vacant = inhabitant_ids.isna() | inhabitant_ids.eq(-1)
+        property_is_owner_occupied = inhabitant_ids.eq(owner_ids)
+        ind_mhr_temp_sale = owner_wants_to_move & (property_is_vacant | property_is_owner_occupied)
         housing_data.loc[np.logical_not(ind_mhr_temp_sale), "Sale Price"] = np.nan
         ind_still_on_sale = housing_data["Temporarily for Sale"].copy()
         housing_data["Temporarily for Sale"] = False

--- a/macromodel/agents/households/households.py
+++ b/macromodel/agents/households/households.py
@@ -780,11 +780,12 @@ class Households(Agent):
         self.ts.max_rent_willing_to_pay.append(max_rent_willing_to_pay)
 
         # Set price of properties of households that are hoping to move.
-        # The property function returns a household-level boolean mask.
+        # Compare owner IDs with moving household IDs, not mask positions.
         household_ids_hoping_to_move = np.flatnonzero(households_hoping_to_move)
         owner_ids = housing_data["Corresponding Owner Household ID"]
         inhabitant_ids = housing_data["Corresponding Inhabitant Household ID"]
         owner_wants_to_move = owner_ids.isin(household_ids_hoping_to_move)
+        # Owners can only list homes they can vacate: vacant or owner-occupied.
         property_is_vacant = inhabitant_ids.isna() | inhabitant_ids.eq(-1)
         property_is_owner_occupied = inhabitant_ids.eq(owner_ids)
         ind_mhr_temp_sale = owner_wants_to_move & (property_is_vacant | property_is_owner_occupied)
@@ -811,6 +812,7 @@ class Households(Agent):
         )
 
         # Set what's up for rent
+        # Rental availability is property-index based; NaN and -1 both mean vacancy.
         prev_up_for_rent = np.flatnonzero(housing_data["Up for Rent"].eq(True).values)
         inhabitant_ids = housing_data["Corresponding Inhabitant Household ID"].values
         now_up_for_rent = np.where(np.logical_or(np.isnan(inhabitant_ids), inhabitant_ids == -1))[0]

--- a/macromodel/country/country.py
+++ b/macromodel/country/country.py
@@ -817,7 +817,7 @@ class Country:
         )
         self.households.compute_target_credit(
             current_sales=self.housing_market.states["current_sales"].loc[
-                self.housing_market.states["current_sales"]["sales_types"] == "Rental"
+                self.housing_market.states["current_sales"]["sales_types"] == "Sell"
             ],
         )
         self.banks.set_interest_rates(central_bank_policy_rate=self.central_bank.ts.current("policy_rate")[0])

--- a/macromodel/country/country.py
+++ b/macromodel/country/country.py
@@ -843,6 +843,7 @@ class Country:
         Updates property ownership, rents, and related financial positions
         after market clearing.
         """
+        # Apply transactions before updating observed ratios so they reflect post-clearing prices.
         self.housing_market.process_housing_market_clearing(
             household_states=self.households.states,
             household_received_mortgages=self.households.ts.current("received_mortgages"),

--- a/macromodel/country/country.py
+++ b/macromodel/country/country.py
@@ -843,16 +843,16 @@ class Country:
         Updates property ownership, rents, and related financial positions
         after market clearing.
         """
+        self.housing_market.process_housing_market_clearing(
+            household_states=self.households.states,
+            household_received_mortgages=self.households.ts.current("received_mortgages"),
+            household_financial_wealth=self.households.ts.current("wealth_financial_assets"),
+        )
         self.housing_market.ts.observed_fraction_value_price.append(
             self.housing_market.compute_observed_fraction_value_price()
         )
         self.housing_market.ts.observed_fraction_rent_value.append(
             self.housing_market.compute_observed_fraction_rent_value()
-        )
-        self.housing_market.process_housing_market_clearing(
-            household_states=self.households.states,
-            household_received_mortgages=self.households.ts.current("received_mortgages"),
-            household_financial_wealth=self.households.ts.current("wealth_financial_assets"),
         )
         self.households.process_housing_market_clearing(
             housing_data=self.housing_market.states["properties"],

--- a/macromodel/markets/housing_market/func/clearing.py
+++ b/macromodel/markets/housing_market/func/clearing.py
@@ -152,6 +152,7 @@ class DefaultHousingMarketClearer(HousingMarketClearer):
             is_rental_market=False,
         )
         sold_property_ids = matching_sales["property_id"].astype(int).values
+        # Sales clear first; sold homes leave the rental pool before rental matching.
         housing_data.loc[sold_property_ids, "Up for Rent"] = False
 
         # Rental market
@@ -304,6 +305,7 @@ class AutomaticHousingMarketClearer(HousingMarketClearer):
             is_rental_market=False,
         )
         sold_property_ids = matching_sales["property_id"].astype(int).values
+        # Sales clear first; sold homes leave the rental pool before rental matching.
         housing_data.loc[sold_property_ids, "Up for Rent"] = False
 
         # Rental market
@@ -376,6 +378,7 @@ class AutomaticHousingMarketClearer(HousingMarketClearer):
         # Collect properties
         property_open_ind = np.where(housing_data[status_field])[0]
         property_prices = housing_data.loc[property_open_ind, price_field].values
+        # Empty sides of the market have no feasible cost matrix to optimize.
         if len(households_with_demand) == 0 or len(property_open_ind) == 0:
             return pd.DataFrame(
                 data={

--- a/macromodel/markets/housing_market/func/clearing.py
+++ b/macromodel/markets/housing_market/func/clearing.py
@@ -151,6 +151,8 @@ class DefaultHousingMarketClearer(HousingMarketClearer):
             max_willing_to_pay=max_price_willing_to_pay,
             is_rental_market=False,
         )
+        sold_property_ids = matching_sales["property_id"].astype(int).values
+        housing_data.loc[sold_property_ids, "Up for Rent"] = False
 
         # Rental market
         matching_rental = self.perform_matching(
@@ -301,6 +303,8 @@ class AutomaticHousingMarketClearer(HousingMarketClearer):
             max_willing_to_pay=max_price_willing_to_pay,
             is_rental_market=False,
         )
+        sold_property_ids = matching_sales["property_id"].astype(int).values
+        housing_data.loc[sold_property_ids, "Up for Rent"] = False
 
         # Rental market
         matching_rental = self.perform_matching(

--- a/macromodel/markets/housing_market/func/clearing.py
+++ b/macromodel/markets/housing_market/func/clearing.py
@@ -376,6 +376,17 @@ class AutomaticHousingMarketClearer(HousingMarketClearer):
         # Collect properties
         property_open_ind = np.where(housing_data[status_field])[0]
         property_prices = housing_data.loc[property_open_ind, price_field].values
+        if len(households_with_demand) == 0 or len(property_open_ind) == 0:
+            return pd.DataFrame(
+                data={
+                    "sales_types": [],
+                    "property_id": [],
+                    "property_value": [],
+                    "price_or_rent": [],
+                    "seller_id": [],
+                    "buyer_id": [],
+                }
+            )
 
         # Create a cost matrix
         cost = sp.spatial.distance_matrix(

--- a/macromodel/markets/housing_market/housing_market.py
+++ b/macromodel/markets/housing_market/housing_market.py
@@ -326,6 +326,47 @@ class HousingMarket:
             max_rent_willing_to_pay=max_rent_willing_to_pay,
         )
 
+    def _filter_feasible_current_sales(
+        self,
+        household_received_mortgages: np.ndarray,
+        household_financial_wealth: np.ndarray,
+    ) -> pd.DataFrame:
+        current_sales = self.states["current_sales"]
+        if len(current_sales) == 0:
+            return current_sales.copy()
+
+        feasible_sales = current_sales.copy()
+        sell_positions = np.flatnonzero(feasible_sales["sales_types"].eq("Sell").to_numpy())
+        if len(sell_positions) > 0:
+            buyer_ids = feasible_sales["buyer_id"].astype(int).to_numpy()
+            prices = feasible_sales["price_or_rent"].to_numpy(dtype=float)
+            financing_ok = np.ones(len(feasible_sales), dtype=bool)
+            sell_buyers = buyer_ids[sell_positions]
+            financing_ok[sell_positions] = np.logical_or(
+                household_received_mortgages[sell_buyers] > 0,
+                household_financial_wealth[sell_buyers] >= prices[sell_positions],
+            )
+            feasible_sales = feasible_sales.loc[financing_ok].copy()
+
+        initial_inhabitants = self.states["properties"]["Corresponding Inhabitant Household ID"].fillna(-1).astype(int)
+        while len(feasible_sales) > 0:
+            moving_households = set(feasible_sales["buyer_id"].astype(int).tolist())
+            keep_transaction = []
+            for _, sale in feasible_sales.iterrows():
+                buyer_id = int(sale["buyer_id"])
+                property_id = int(sale["property_id"])
+                inhabitant_id = int(initial_inhabitants.at[property_id])
+                keep_transaction.append(
+                    inhabitant_id == -1 or inhabitant_id == buyer_id or inhabitant_id in moving_households
+                )
+
+            keep_transaction = np.array(keep_transaction, dtype=bool)
+            if keep_transaction.all():
+                break
+            feasible_sales = feasible_sales.loc[keep_transaction].copy()
+
+        return feasible_sales.reset_index(drop=True)
+
     @staticmethod
     def _perform_linear_regression(x: np.ndarray, y: np.ndarray) -> np.ndarray:
         """Perform linear regression with error handling.
@@ -446,6 +487,11 @@ class HousingMarket:
             This method ensures all market clearing outcomes are properly
             reflected in the system state.
         """
+        self.states["current_sales"] = self._filter_feasible_current_sales(
+            household_received_mortgages=household_received_mortgages,
+            household_financial_wealth=household_financial_wealth,
+        )
+
         total_number_of_bought_houses = 0
         total_number_of_newly_rented_houses = 0
         for index, sale in self.states["current_sales"].iterrows():

--- a/macromodel/markets/housing_market/housing_market.py
+++ b/macromodel/markets/housing_market/housing_market.py
@@ -492,6 +492,20 @@ class HousingMarket:
             household_financial_wealth=household_financial_wealth,
         )
 
+        def clear_previous_residence(household_id: int, property_id: int) -> None:
+            if property_id == -1:
+                return
+            current_inhabitant = self.states["properties"].at[
+                property_id,
+                "Corresponding Inhabitant Household ID",
+            ]
+            if not pd.isna(current_inhabitant) and int(current_inhabitant) == household_id:
+                self.states["properties"].loc[
+                    property_id,
+                    "Corresponding Inhabitant Household ID",
+                ] = -1
+                self.states["properties"].loc[property_id, "Is Owner-Occupied"] = 0
+
         total_number_of_bought_houses = 0
         total_number_of_newly_rented_houses = 0
         for index, sale in self.states["current_sales"].iterrows():
@@ -503,11 +517,7 @@ class HousingMarket:
             prev_property_id = household_states["Corresponding Inhabited House ID"][buyer_id]
             if sale["sales_types"] == "Rental":
                 self.states["properties"].loc[property_id, "Corresponding Inhabitant Household ID"] = buyer_id
-                if prev_property_id != -1:
-                    self.states["properties"].loc[
-                        prev_property_id,
-                        "Corresponding Inhabitant Household ID",
-                    ] = -1
+                clear_previous_residence(buyer_id, prev_property_id)
                 household_states["Corresponding Inhabited House ID"][buyer_id] = property_id
                 household_states["Tenure Status of the Main Residence"][buyer_id] = 3
                 household_states["corr_renters"][seller_id].append(buyer_id)
@@ -525,11 +535,7 @@ class HousingMarket:
 
                     # Corresponding inhabitant households
                     self.states["properties"].loc[property_id, "Corresponding Inhabitant Household ID"] = buyer_id
-                    if prev_property_id != -1:
-                        self.states["properties"].loc[
-                            prev_property_id,
-                            "Corresponding Inhabitant Household ID",
-                        ] = -1
+                    clear_previous_residence(buyer_id, prev_property_id)
 
                     # Corresponding inhabited house ID
                     household_states["Corresponding Inhabited House ID"][buyer_id] = property_id

--- a/macromodel/markets/housing_market/housing_market.py
+++ b/macromodel/markets/housing_market/housing_market.py
@@ -15,7 +15,6 @@ import h5py
 import numpy as np
 import pandas as pd
 
-import macromodel.util.get_histogram
 from macro_data import SyntheticHousingMarket
 from macromodel.configurations import HousingMarketConfiguration
 from macromodel.markets.housing_market.housing_market_ts import (
@@ -158,16 +157,13 @@ class HousingMarket:
         property_data["Up for Rent"] = None
         property_data["Temporarily for Sale"] = False
 
-        # property_data["Corresponding Inhabitant Household ID"].loc[
-        #     :, np.isnan(property_data["Corresponding Inhabitant Household ID"])
-        # ] = -1
-        property_data["Corresponding Inhabitant Household ID"] = macromodel.util.get_histogram.fillna(-1).astype(int)
-        property_data["House ID"] = macromodel.util.get_histogram.fillna(-1).astype(int)
-        property_data["Is Owner-Occupied"] = macromodel.util.get_histogram.fillna(-1).astype(int)
-        property_data["Corresponding Owner Household ID"] = property_data["Corresponding Owner Household ID"].astype(
-            int
-        )
-        property_data["Corresponding Inhabitant Household ID"] = macromodel.util.get_histogram.fillna(-1).astype(int)
+        for column in [
+            "Corresponding Inhabitant Household ID",
+            "House ID",
+            "Is Owner-Occupied",
+            "Corresponding Owner Household ID",
+        ]:
+            property_data[column] = property_data[column].fillna(-1).astype(int)
 
         ts = create_housing_market_timeseries(
             data=property_data,
@@ -248,11 +244,13 @@ class HousingMarket:
 
         # Recording the states of all homes
         states = data.copy()
-        states["Corresponding Inhabitant Household ID"][np.isnan(states["Corresponding Inhabitant Household ID"])] = -1
-        states["House ID"] = macromodel.util.get_histogram.fillna(-1).astype(int)
-        states["Is Owner-Occupied"] = macromodel.util.get_histogram.fillna(-1).astype(int)
-        states["Corresponding Owner Household ID"] = macromodel.util.get_histogram.fillna(-1).astype(int)
-        states["Corresponding Inhabitant Household ID"] = macromodel.util.get_histogram.fillna(-1).astype(int)
+        for column in [
+            "Corresponding Inhabitant Household ID",
+            "House ID",
+            "Is Owner-Occupied",
+            "Corresponding Owner Household ID",
+        ]:
+            states[column] = states[column].fillna(-1).astype(int)
 
         # Create the corresponding time series object
         ts = create_housing_market_timeseries(

--- a/macromodel/markets/housing_market/housing_market.py
+++ b/macromodel/markets/housing_market/housing_market.py
@@ -157,6 +157,7 @@ class HousingMarket:
         property_data["Up for Rent"] = None
         property_data["Temporarily for Sale"] = False
 
+        # Preserve existing IDs; only missing IDs are normalized to -1.
         for column in [
             "Corresponding Inhabitant Household ID",
             "House ID",
@@ -244,6 +245,7 @@ class HousingMarket:
 
         # Recording the states of all homes
         states = data.copy()
+        # Preserve existing IDs; only missing IDs are normalized to -1.
         for column in [
             "Corresponding Inhabitant Household ID",
             "House ID",
@@ -331,6 +333,7 @@ class HousingMarket:
         household_received_mortgages: np.ndarray,
         household_financial_wealth: np.ndarray,
     ) -> pd.DataFrame:
+        """Keep only transactions that can be safely applied to property states."""
         current_sales = self.states["current_sales"]
         if len(current_sales) == 0:
             return current_sales.copy()
@@ -338,6 +341,7 @@ class HousingMarket:
         feasible_sales = current_sales.copy()
         sell_positions = np.flatnonzero(feasible_sales["sales_types"].eq("Sell").to_numpy())
         if len(sell_positions) > 0:
+            # Sale transactions need either a mortgage or enough liquid wealth.
             buyer_ids = feasible_sales["buyer_id"].astype(int).to_numpy()
             prices = feasible_sales["price_or_rent"].to_numpy(dtype=float)
             financing_ok = np.ones(len(feasible_sales), dtype=bool)
@@ -348,6 +352,7 @@ class HousingMarket:
             )
             feasible_sales = feasible_sales.loc[financing_ok].copy()
 
+        # Occupied homes can transfer only if the current inhabitant also moves.
         initial_inhabitants = self.states["properties"]["Corresponding Inhabitant Household ID"].fillna(-1).astype(int)
         while len(feasible_sales) > 0:
             moving_households = set(feasible_sales["buyer_id"].astype(int).tolist())
@@ -487,12 +492,14 @@ class HousingMarket:
             This method ensures all market clearing outcomes are properly
             reflected in the system state.
         """
+        # Downstream state updates should only see transactions that can close.
         self.states["current_sales"] = self._filter_feasible_current_sales(
             household_received_mortgages=household_received_mortgages,
             household_financial_wealth=household_financial_wealth,
         )
 
         def clear_previous_residence(household_id: int, property_id: int) -> None:
+            """Clear the old residence only if this household still inhabits it."""
             if property_id == -1:
                 return
             current_inhabitant = self.states["properties"].at[

--- a/tests/test_macromodel/unit/test_agents/test_households/func/test_property_performance.py
+++ b/tests/test_macromodel/unit/test_agents/test_households/func/test_property_performance.py
@@ -7,6 +7,50 @@ property market, particularly the housing listing logic.
 import time
 
 import numpy as np
+import pandas as pd
+
+from macromodel.agents.households.households import Households
+
+
+class _TimeseriesList:
+    def __init__(self):
+        self.values = []
+
+    def append(self, value):
+        self.values.append(value)
+
+
+class _HouseholdTimeseries:
+    def __init__(self):
+        self.max_price_willing_to_pay = _TimeseriesList()
+        self.max_rent_willing_to_pay = _TimeseriesList()
+
+    def current(self, key):
+        if key == "expected_income":
+            return np.full(5, 50_000.0)
+        if key == "wealth_financial_assets":
+            return np.full(5, 25_000.0)
+        raise KeyError(key)
+
+
+class _PropertyDemand:
+    def compute_demand(self, **kwargs):
+        max_price = np.full(5, np.nan)
+        max_rent = np.full(5, np.nan)
+        households_hoping_to_move = np.array([False, False, False, True, False])
+        return max_price, max_rent, households_hoping_to_move
+
+    def compute_initial_sale_price(self, property_values):
+        return 1.1 * property_values
+
+    def compute_updated_sale_price(self, sale_prices):
+        return sale_prices
+
+    def compute_offered_rent_for_new_properties(self, property_value, observed_fraction_rent_value):
+        return observed_fraction_rent_value[0] * property_value + observed_fraction_rent_value[1]
+
+    def compute_offered_rent_for_existing_properties(self, current_offered_rent):
+        return current_offered_rent
 
 
 class TestHouseholdPropertyPerformance:
@@ -44,3 +88,47 @@ class TestHouseholdPropertyPerformance:
         assert isinstance(ind_mhr_temp_sale, np.ndarray)
         assert ind_mhr_temp_sale.dtype == bool
         assert len(ind_mhr_temp_sale) == n_houses
+
+    def test_household_hoping_to_move_mask_lists_matching_owner_id(self):
+        """Regression: list only homes that a moving owner can make available.
+
+        A moving owner may own several properties. The previous listing logic
+        put all of them on the sale market, including tenant-occupied homes.
+        This test verifies that owner-occupied and vacant homes can be listed,
+        while tenant-occupied homes are left off the owner-occupier market.
+        """
+        households = object.__new__(Households)
+        households.functions = {"property": _PropertyDemand()}
+        households.states = {"Tenure Status of the Main Residence": np.ones(5)}
+        households.ts = _HouseholdTimeseries()
+
+        housing_data = pd.DataFrame(
+            {
+                "House ID": [0, 1, 2, 3, 4],
+                "Value": [100.0, 200.0, 300.0, 400.0, 500.0],
+                "Rent": [1.0, 2.0, 3.0, 4.0, 5.0],
+                "Corresponding Inhabitant Household ID": [0.0, 1.0, 3.0, 4.0, -1.0],
+                "Corresponding Owner Household ID": [0, 1, 3, 3, 3],
+                "Is Owner-Occupied": [1, 1, 1, 0, 0],
+                "Sale Price": [np.nan, np.nan, np.nan, np.nan, np.nan],
+                "Temporarily for Sale": [False, False, False, False, False],
+                "Up for Rent": [False, False, False, False, False],
+                "Newly on the Rental Market": [False, False, False, False, False],
+            }
+        )
+
+        households.prepare_housing_market_clearing(
+            housing_data=housing_data,
+            observed_fraction_value_price=np.array([1.0, 0.0]),
+            observed_fraction_rent_value=np.array([0.01, 0.0]),
+            expected_hpi_growth=0.0,
+            assumed_mortgage_maturity=120,
+            rental_income_taxes=0.0,
+        )
+
+        assert housing_data["Temporarily for Sale"].tolist() == [False, False, True, False, True]
+        assert np.isnan(housing_data.loc[0, "Sale Price"])
+        assert np.isnan(housing_data.loc[1, "Sale Price"])
+        assert housing_data.loc[2, "Sale Price"] == 330.0
+        assert np.isnan(housing_data.loc[3, "Sale Price"])
+        assert housing_data.loc[4, "Sale Price"] == 550.0

--- a/tests/test_macromodel/unit/test_agents/test_households/func/test_property_performance.py
+++ b/tests/test_macromodel/unit/test_agents/test_households/func/test_property_performance.py
@@ -132,3 +132,38 @@ class TestHouseholdPropertyPerformance:
         assert housing_data.loc[2, "Sale Price"] == 330.0
         assert np.isnan(housing_data.loc[3, "Sale Price"])
         assert housing_data.loc[4, "Sale Price"] == 550.0
+
+    def test_vacant_negative_one_homes_are_listed_for_rent(self):
+        """Regression: vacant homes marked with -1 enter the rental market."""
+        households = object.__new__(Households)
+        households.functions = {"property": _PropertyDemand()}
+        households.states = {"Tenure Status of the Main Residence": np.ones(5)}
+        households.ts = _HouseholdTimeseries()
+
+        housing_data = pd.DataFrame(
+            {
+                "House ID": [0, 1, 2, 3, 4],
+                "Value": [100.0, 200.0, 300.0, 400.0, 500.0],
+                "Rent": [9.0, 9.0, 3.0, 4.0, 5.0],
+                "Corresponding Inhabitant Household ID": [np.nan, -1.0, 2.0, 3.0, 4.0],
+                "Corresponding Owner Household ID": [0, 1, 2, 3, 4],
+                "Is Owner-Occupied": [0, 0, 1, 1, 1],
+                "Sale Price": [np.nan, np.nan, np.nan, np.nan, np.nan],
+                "Temporarily for Sale": [False, False, False, False, False],
+                "Up for Rent": [False, False, False, False, False],
+                "Newly on the Rental Market": [False, False, False, False, False],
+            }
+        )
+
+        households.prepare_housing_market_clearing(
+            housing_data=housing_data,
+            observed_fraction_value_price=np.array([1.0, 0.0]),
+            observed_fraction_rent_value=np.array([0.01, 0.0]),
+            expected_hpi_growth=0.0,
+            assumed_mortgage_maturity=120,
+            rental_income_taxes=0.0,
+        )
+
+        assert housing_data["Up for Rent"].tolist() == [True, True, False, False, False]
+        assert housing_data["Newly on the Rental Market"].tolist() == [True, True, False, False, False]
+        assert housing_data["Rent"].tolist() == [1.0, 2.0, 3.0, 4.0, 5.0]

--- a/tests/test_macromodel/unit/test_agents/test_households/func/test_property_probability.py
+++ b/tests/test_macromodel/unit/test_agents/test_households/func/test_property_probability.py
@@ -68,8 +68,8 @@ class TestHouseholdProbabilityOfBuying:
         """
         np.random.seed(42)  # For reproducibility
 
-        # Single household that is renting (status = 0)
-        household_residence_tenure_status = np.array([0])
+        # Single household that is renting (status = 3)
+        household_residence_tenure_status = np.array([3])
         household_income = np.array([50000.0])  # Moderate income
         household_financial_wealth = np.array([10000.0])  # Some savings
 
@@ -147,8 +147,8 @@ class TestHouseholdProbabilityOfBuying:
         np.random.seed(123)
 
         n_households = 10
-        # Mix of renters (0) and people in social housing (-1)
-        household_residence_tenure_status = np.array([-1, 0, 0, 0, -1, 0, 0, -1, 0, 0])
+        # Mix of renters (3) and people in social housing (-1)
+        household_residence_tenure_status = np.array([-1, 3, 3, 3, -1, 3, 3, -1, 3, 3])
 
         # Varying incomes
         household_income = np.linspace(20000, 100000, n_households)
@@ -179,3 +179,26 @@ class TestHouseholdProbabilityOfBuying:
             if not np.isnan(max_rent[i]):
                 assert np.isfinite(max_rent[i]), f"Household {i}: max_rent must be finite"
                 assert max_rent[i] > 0, f"Household {i}: max_rent must be positive"
+
+    def test_renter_status_three_gets_housing_demand(self, property_demand_calculator, minimal_housing_data):
+        """Regression: renters use tenure status 3, not 0.
+
+        With the previous ``status == 0`` check, renter households did not enter
+        the move/buy/rent decision, so rental demand could vanish even when
+        renters were configured to consider moving.
+        """
+        np.random.seed(321)
+
+        max_price, max_rent, _ = property_demand_calculator.compute_demand(
+            housing_data=minimal_housing_data,
+            household_residence_tenure_status=np.array([3]),
+            household_income=np.array([50000.0]),
+            household_financial_wealth=np.array([10000.0]),
+            observed_fraction_value_price=np.array([1.0, 0.0]),
+            observed_fraction_rent_value=np.array([0.005, 0.0]),
+            expected_hpi_growth=0.02,
+            assumed_mortgage_maturity=25,
+            rental_income_taxes=0.2,
+        )
+
+        assert not (np.isnan(max_price[0]) and np.isnan(max_rent[0]))

--- a/tests/test_macromodel/unit/test_country/test_country.py
+++ b/tests/test_macromodel/unit/test_country/test_country.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pandas as pd
 
 from macromodel.configurations import CountryConfiguration, ExchangeRatesConfiguration
 from macromodel.country import Country
@@ -47,3 +48,54 @@ class TestCountry:
 
     def test__country(self, test_country):
         assert test_country is not None
+
+    def test_prepare_credit_market_uses_home_sales_for_household_mortgages(self):
+        """Regression: household mortgages are requested for purchases, not rentals.
+
+        The previous country-level preparation passed rental rows to household
+        target-credit computation. Mortgage demand then missed actual home-sale
+        buyers and households could not finance purchases correctly.
+        """
+
+        class DummyTimeSeries:
+            def current(self, key):
+                return [0.0]
+
+        class DummyFirms:
+            def compute_target_credit(self, estimated_growth, estimated_inflation):
+                pass
+
+        class DummyHouseholds:
+            def compute_target_credit(self, current_sales):
+                self.current_sales = current_sales
+
+        class DummyBanks:
+            def set_interest_rates(self, central_bank_policy_rate):
+                pass
+
+        country = object.__new__(Country)
+        country.firms = DummyFirms()
+        country.households = DummyHouseholds()
+        country.banks = DummyBanks()
+        country.economy = type("DummyEconomy", (), {"ts": DummyTimeSeries()})()
+        country.central_bank = type("DummyCentralBank", (), {"ts": DummyTimeSeries()})()
+        country.housing_market = type(
+            "DummyHousingMarket",
+            (),
+            {
+                "states": {
+                    "current_sales": pd.DataFrame(
+                        {
+                            "sales_types": ["Rental", "Sell"],
+                            "buyer_id": [1, 2],
+                            "price_or_rent": [10.0, 100.0],
+                        }
+                    )
+                }
+            },
+        )()
+
+        country.prepare_credit_market_clearing()
+
+        assert country.households.current_sales["sales_types"].tolist() == ["Sell"]
+        assert country.households.current_sales["price_or_rent"].tolist() == [100.0]

--- a/tests/test_macromodel/unit/test_country/test_country.py
+++ b/tests/test_macromodel/unit/test_country/test_country.py
@@ -99,3 +99,86 @@ class TestCountry:
 
         assert country.households.current_sales["sales_types"].tolist() == ["Sell"]
         assert country.households.current_sales["price_or_rent"].tolist() == [100.0]
+
+    def test_housing_market_ratios_are_recorded_after_clearing(self):
+        """Regression: observed housing ratios use post-clearing market state."""
+
+        class DummyObservedSeries(list):
+            def __init__(self, events, name):
+                super().__init__()
+                self.events = events
+                self.name = name
+
+            def append(self, value):
+                self.events.append(self.name)
+                super().append(value)
+
+        class DummyHouseholdTimeSeries:
+            def current(self, key):
+                if key == "received_mortgages":
+                    return np.array([100.0])
+                if key == "wealth_financial_assets":
+                    return np.array([0.0])
+                raise KeyError(key)
+
+        class DummyHouseholds:
+            def __init__(self, events):
+                self.events = events
+                self.states = {}
+                self.ts = DummyHouseholdTimeSeries()
+
+            def process_housing_market_clearing(self, **kwargs):
+                self.events.append("households")
+
+        class DummyGovernmentTimeSeries:
+            def current(self, key):
+                return [np.array([])]
+
+        class DummyHousingMarket:
+            def __init__(self):
+                self.events = []
+                self.states = {
+                    "properties": pd.DataFrame(),
+                    "current_sales": pd.DataFrame(
+                        {
+                            "sales_types": ["Sell"],
+                            "buyer_id": [0],
+                            "price_or_rent": [100.0],
+                        }
+                    ),
+                }
+                self.ts = type(
+                    "DummyHousingTimeSeries",
+                    (),
+                    {
+                        "observed_fraction_value_price": DummyObservedSeries(self.events, "value"),
+                        "observed_fraction_rent_value": DummyObservedSeries(self.events, "rent"),
+                    },
+                )()
+
+            def process_housing_market_clearing(self, **kwargs):
+                self.events.append("housing")
+
+            def compute_observed_fraction_value_price(self):
+                assert self.events == ["housing"]
+                return np.array([1.0, 0.0])
+
+            def compute_observed_fraction_rent_value(self):
+                assert self.events == ["housing", "value"]
+                return np.array([0.01, 0.0])
+
+        country = object.__new__(Country)
+        country.housing_market = DummyHousingMarket()
+        country.households = DummyHouseholds(country.housing_market.events)
+        country.central_government = type(
+            "DummyGovernment",
+            (),
+            {
+                "functions": {"social_housing": object()},
+                "ts": DummyGovernmentTimeSeries(),
+            },
+        )()
+
+        country.process_housing_market_clearing()
+
+        assert country.housing_market.events == ["housing", "value", "rent", "households"]

--- a/tests/test_macromodel/unit/test_markets/test_housing_market/test_housing_market.py
+++ b/tests/test_macromodel/unit/test_markets/test_housing_market/test_housing_market.py
@@ -1,2 +1,51 @@
-class TestLabourMarket:
-    pass
+from types import SimpleNamespace
+
+import numpy as np
+import pandas as pd
+
+from macromodel.configurations import HousingMarketConfiguration
+from macromodel.markets.housing_market.housing_market import HousingMarket
+
+
+def _housing_data():
+    return pd.DataFrame(
+        {
+            "House ID": [10, 11],
+            "Value": [100.0, 200.0],
+            "Rent": [1.0, 2.0],
+            "Corresponding Inhabitant Household ID": [3.0, np.nan],
+            "Corresponding Owner Household ID": [5.0, 6.0],
+            "Is Owner-Occupied": [1.0, 0.0],
+        }
+    )
+
+
+def test_from_data_preserves_household_and_property_ids(test_config):
+    """Regression: HousingMarket.from_data must preserve property and household IDs."""
+    market = HousingMarket.from_data(
+        country_name="FRA",
+        scale=1,
+        data=_housing_data(),
+        config=test_config["FRA"]["housing_market"],
+    )
+
+    assert market.states["House ID"].tolist() == [10, 11]
+    assert market.states["Corresponding Owner Household ID"].tolist() == [5, 6]
+    assert market.states["Corresponding Inhabitant Household ID"].tolist() == [3, -1]
+    assert market.states["Is Owner-Occupied"].tolist() == [1, 0]
+
+
+def test_from_pickled_market_preserves_household_and_property_ids():
+    """Regression: pickled housing-market data keeps existing property IDs."""
+    market = HousingMarket.from_pickled_market(
+        synthetic_housing_market=SimpleNamespace(housing_market_data=_housing_data()),
+        housing_market_configuration=HousingMarketConfiguration(),
+        scale=1,
+        country_name="FRA",
+    )
+
+    properties = market.states["properties"]
+    assert properties["House ID"].tolist() == [10, 11]
+    assert properties["Corresponding Owner Household ID"].tolist() == [5, 6]
+    assert properties["Corresponding Inhabitant Household ID"].tolist() == [3, -1]
+    assert properties["Is Owner-Occupied"].tolist() == [1, 0]

--- a/tests/test_macromodel/unit/test_markets/test_housing_market/test_housing_market.py
+++ b/tests/test_macromodel/unit/test_markets/test_housing_market/test_housing_market.py
@@ -122,3 +122,56 @@ def test_automatic_clearer_returns_empty_transactions_without_matches():
         "seller_id",
         "buyer_id",
     ]
+
+
+def test_sale_does_not_displace_inhabitant_without_completed_move():
+    """Regression: a sale cannot overwrite an inhabitant who has not moved."""
+    market = object.__new__(HousingMarket)
+    market.states = {
+        "properties": pd.DataFrame(
+            {
+                "House ID": [0, 1],
+                "Value": [100.0, 200.0],
+                "Rent": [1.0, 2.0],
+                "Corresponding Inhabitant Household ID": [0, 1],
+                "Corresponding Owner Household ID": [0, 1],
+                "Is Owner-Occupied": [1, 1],
+            }
+        ),
+        "current_sales": pd.DataFrame(
+            {
+                "sales_types": ["Sell"],
+                "property_id": [0],
+                "seller_id": [0],
+                "buyer_id": [1],
+                "property_value": [100.0],
+                "price_or_rent": [100.0],
+            }
+        ),
+    }
+    market.ts = SimpleNamespace(
+        total_number_of_houses_rented=[],
+        total_number_of_houses_owner_occupied=[],
+        total_number_of_houses_unoccupied=[],
+        total_number_of_bought_houses=[],
+        total_number_of_newly_rented_houses=[],
+    )
+    household_states = {
+        "Corresponding Inhabited House ID": np.array([0, 1]),
+        "Corresponding Property Owner": np.array([0, 1]),
+        "Tenure Status of the Main Residence": np.array([1, 1]),
+        "corr_renters": [[], []],
+    }
+
+    market.process_housing_market_clearing(
+        household_states=household_states,
+        household_received_mortgages=np.array([0.0, 100.0]),
+        household_financial_wealth=np.array([0.0, 0.0]),
+    )
+
+    properties = market.states["properties"]
+    assert market.states["current_sales"].empty
+    assert properties["Corresponding Owner Household ID"].tolist() == [0, 1]
+    assert properties["Corresponding Inhabitant Household ID"].tolist() == [0, 1]
+    assert household_states["Corresponding Inhabited House ID"].tolist() == [0, 1]
+    assert market.ts.total_number_of_bought_houses == [[0]]

--- a/tests/test_macromodel/unit/test_markets/test_housing_market/test_housing_market.py
+++ b/tests/test_macromodel/unit/test_markets/test_housing_market/test_housing_market.py
@@ -86,3 +86,39 @@ def test_property_sold_this_period_is_not_also_rented():
 
         assert current_sales["sales_types"].tolist() == ["Sell"]
         assert current_sales["property_id"].tolist() == [0]
+
+
+def test_automatic_clearer_returns_empty_transactions_without_matches():
+    """Regression: automatic matching handles empty demand and empty supply."""
+    clearer = AutomaticHousingMarketClearer(random_assignment_shock_variance=0.0)
+
+    housing_data = pd.DataFrame(
+        {
+            "House ID": [0],
+            "Value": [100.0],
+            "Rent": [1.0],
+            "Sale Price": [100.0],
+            "Corresponding Inhabitant Household ID": [-1],
+            "Corresponding Owner Household ID": [0],
+            "Is Owner-Occupied": [0],
+            "Temporarily for Sale": [False],
+            "Up for Rent": [False],
+        }
+    )
+
+    current_sales = clearer.clear(
+        housing_data=housing_data,
+        household_main_residence_tenure_status=np.array([1]),
+        max_price_willing_to_pay=np.array([np.nan]),
+        max_rent_willing_to_pay=np.array([np.nan]),
+    )
+
+    assert current_sales.empty
+    assert current_sales.columns.tolist() == [
+        "sales_types",
+        "property_id",
+        "property_value",
+        "price_or_rent",
+        "seller_id",
+        "buyer_id",
+    ]

--- a/tests/test_macromodel/unit/test_markets/test_housing_market/test_housing_market.py
+++ b/tests/test_macromodel/unit/test_markets/test_housing_market/test_housing_market.py
@@ -4,6 +4,10 @@ import numpy as np
 import pandas as pd
 
 from macromodel.configurations import HousingMarketConfiguration
+from macromodel.markets.housing_market.func.clearing import (
+    AutomaticHousingMarketClearer,
+    DefaultHousingMarketClearer,
+)
 from macromodel.markets.housing_market.housing_market import HousingMarket
 
 
@@ -49,3 +53,36 @@ def test_from_pickled_market_preserves_household_and_property_ids():
     assert properties["Corresponding Owner Household ID"].tolist() == [5, 6]
     assert properties["Corresponding Inhabitant Household ID"].tolist() == [3, -1]
     assert properties["Is Owner-Occupied"].tolist() == [1, 0]
+
+
+def test_property_sold_this_period_is_not_also_rented():
+    """Regression: one property cannot clear in both sale and rental markets."""
+    housing_data = pd.DataFrame(
+        {
+            "House ID": [0],
+            "Value": [100.0],
+            "Rent": [1.0],
+            "Sale Price": [100.0],
+            "Corresponding Inhabitant Household ID": [-1],
+            "Corresponding Owner Household ID": [0],
+            "Is Owner-Occupied": [0],
+            "Temporarily for Sale": [True],
+            "Up for Rent": [True],
+        }
+    )
+    max_price_willing_to_pay = np.array([np.nan, 100.0, np.nan])
+    max_rent_willing_to_pay = np.array([np.nan, np.nan, 10.0])
+
+    for clearer in [
+        DefaultHousingMarketClearer(random_assignment_shock_variance=0.0),
+        AutomaticHousingMarketClearer(random_assignment_shock_variance=0.0),
+    ]:
+        current_sales = clearer.clear(
+            housing_data=housing_data.copy(),
+            household_main_residence_tenure_status=np.array([1, 1, 3]),
+            max_price_willing_to_pay=max_price_willing_to_pay,
+            max_rent_willing_to_pay=max_rent_willing_to_pay,
+        )
+
+        assert current_sales["sales_types"].tolist() == ["Sell"]
+        assert current_sales["property_id"].tolist() == [0]

--- a/tests/test_macromodel/unit/test_markets/test_housing_market/test_housing_market.py
+++ b/tests/test_macromodel/unit/test_markets/test_housing_market/test_housing_market.py
@@ -175,3 +175,55 @@ def test_sale_does_not_displace_inhabitant_without_completed_move():
     assert properties["Corresponding Inhabitant Household ID"].tolist() == [0, 1]
     assert household_states["Corresponding Inhabited House ID"].tolist() == [0, 1]
     assert market.ts.total_number_of_bought_houses == [[0]]
+
+
+def test_swap_sales_do_not_clear_new_inhabitant_from_previous_residence():
+    """Regression: clearing old residences must respect transaction order."""
+    market = object.__new__(HousingMarket)
+    market.states = {
+        "properties": pd.DataFrame(
+            {
+                "House ID": [0, 1],
+                "Value": [100.0, 200.0],
+                "Rent": [1.0, 2.0],
+                "Corresponding Inhabitant Household ID": [0, 1],
+                "Corresponding Owner Household ID": [0, 1],
+                "Is Owner-Occupied": [1, 1],
+            }
+        ),
+        "current_sales": pd.DataFrame(
+            {
+                "sales_types": ["Sell", "Sell"],
+                "property_id": [1, 0],
+                "seller_id": [1, 0],
+                "buyer_id": [0, 1],
+                "property_value": [200.0, 100.0],
+                "price_or_rent": [200.0, 100.0],
+            }
+        ),
+    }
+    market.ts = SimpleNamespace(
+        total_number_of_houses_rented=[],
+        total_number_of_houses_owner_occupied=[],
+        total_number_of_houses_unoccupied=[],
+        total_number_of_bought_houses=[],
+        total_number_of_newly_rented_houses=[],
+    )
+    household_states = {
+        "Corresponding Inhabited House ID": np.array([0, 1]),
+        "Corresponding Property Owner": np.array([0, 1]),
+        "Tenure Status of the Main Residence": np.array([1, 1]),
+        "corr_renters": [[], []],
+    }
+
+    market.process_housing_market_clearing(
+        household_states=household_states,
+        household_received_mortgages=np.array([200.0, 100.0]),
+        household_financial_wealth=np.array([0.0, 0.0]),
+    )
+
+    properties = market.states["properties"]
+    assert properties["Corresponding Inhabitant Household ID"].tolist() == [1, 0]
+    assert properties["Corresponding Owner Household ID"].tolist() == [1, 0]
+    assert household_states["Corresponding Inhabited House ID"].tolist() == [1, 0]
+    assert market.ts.total_number_of_houses_unoccupied == [[0]]


### PR DESCRIPTION
## Summary

This PR fixes several housing-market accounting and clearing issues that could leave households or properties in inconsistent states after market clearing.

The main goal is to make housing transactions internally consistent: households that buy or rent should end up inhabiting the corresponding property, sold properties should not also be rented in the same clearing, occupied homes should not be sold out from under households that did not move, and housing-market IDs should be preserved during initialization.

## What changed

- Correct private renter participation in housing demand.
  Private renters use tenure status `3`, but the demand code was checking the wrong renter status. This could prevent renters from entering the housing-market demand calculation.

- Fix sale listings for households hoping to move.
  The moving-household mask is now converted to household IDs before comparing with property owner IDs. This avoids treating boolean mask positions as owner IDs.

- Include `-1` vacancies in rental listings.
  The rental market now treats both `NaN` and `-1` inhabitant IDs as vacant homes.

- Use completed housing sales for mortgage demand.
  Household mortgage demand is based on housing sales, not unrelated transaction rows.

- Record observed housing ratios after clearing.
  Price/value and rent/value ratios are now updated after transactions have been applied, so they reflect the post-clearing market state.

- Preserve housing-market IDs during initialization.
  Existing household/property IDs are kept, while only missing IDs are normalized to `-1`.

- Prevent sold homes from also being rented.
  Sales clear before rentals, and sold properties are removed from the rental pool before rental matching.

- Handle empty automatic housing matches.
  The automatic clearer now returns an empty transaction table when there is no demand or no available property, instead of trying to optimize an empty cost matrix.

- Prevent infeasible occupied sales.
  A sale cannot complete if it would overwrite an inhabitant who has not completed a move in the same clearing.

- Preserve occupants during move chains/swaps.
  When clearing a buyer’s previous residence, the code only clears it if that buyer is still the recorded inhabitant. This avoids deleting a new occupant in swap-like transaction chains.

## Tests

Added regression coverage for:

- renter tenure status `3` generating housing demand;
- moving-household sale listing using owner IDs correctly;
- `-1` vacant homes being listed for rent;
- mortgage demand using completed home sales;
- housing ratios being recorded after clearing;
- housing-market initialization preserving IDs;
- sold properties not also being rented;
- automatic clearing with empty demand/supply;
- occupied sales not displacing stationary inhabitants;
- swap/move chains not clearing the wrong occupant.


tests\test_macromodel\unit\test_agents\test_households\func\test_property_probability.py tests\test_macromodel\unit\test_agents\test_households\func\test_property_performance.py tests\test_macromodel\unit\test_country\test_country.py tests\test_macromodel\unit\test_markets\test_housing_market\test_housing_market.py